### PR TITLE
Add fallback mode observability for crt.sh degradation

### DIFF
--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -22,6 +22,7 @@ from domain_scout.config import ProfileName, ScoutConfig
 from domain_scout.delta import compute_delta
 from domain_scout.models import DeltaReport, EntityInput, ScoutResult
 from domain_scout.scout import Scout
+from domain_scout.sources.ct_logs import CTLogSource
 
 log = structlog.get_logger()
 
@@ -101,11 +102,19 @@ def create_app(
             log.warning("ready.crt_sh_error", error=str(exc))
             crt_sh = "unreachable"
 
+        breaker = CTLogSource._breaker
+        cb_state = breaker.state if breaker is not None else "unknown"
+
         status = "ready" if crt_sh == "ok" else "degraded"
+        if cb_state == "open":
+            status = "degraded"
         result: dict[str, Any] = {
             "status": status,
             "version": _VERSION,
-            "details": {"crt_sh": crt_sh},
+            "details": {
+                "crt_sh": crt_sh,
+                "crt_sh_postgres_circuit_breaker": cb_state,
+            },
         }
         app.state.ready_cache = result
         app.state.ready_cache_ts = now

--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -333,7 +333,10 @@ def _print_table(result: ScoutResult) -> None:
     )
 
     if result.run_metadata.errors:
-        typer.echo(f"  Warnings: {len(result.run_metadata.errors)}", err=True)
+        typer.echo(f"  Errors: {len(result.run_metadata.errors)}", err=True)
+    if result.run_metadata.warnings:
+        for w in result.run_metadata.warnings:
+            typer.echo(f"  Warning: {w}", err=True)
 
 
 if __name__ == "__main__":

--- a/domain_scout/delta.py
+++ b/domain_scout/delta.py
@@ -149,4 +149,23 @@ def _check_warnings(baseline: ScoutResult, current: ScoutResult) -> list[DeltaWa
             )
         )
 
+    b_fb = _has_ct_fallback(baseline)
+    c_fb = _has_ct_fallback(current)
+    if b_fb != c_fb:
+        warnings.append(
+            DeltaWarning(
+                code="ct_fallback_asymmetry",
+                message=(
+                    "CT Postgres was unavailable in one scan but not the other — "
+                    "domain differences may reflect data-source availability, "
+                    "not real changes"
+                ),
+            )
+        )
+
     return warnings
+
+
+def _has_ct_fallback(result: ScoutResult) -> bool:
+    """Check if a scan used the JSON fallback."""
+    return any("JSON fallback" in w for w in result.run_metadata.warnings)

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -55,6 +55,7 @@ class RunMetadata(BaseModel):
     timed_out: bool = False
     seed_count: int = 0
     errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
     config: dict[str, object] = Field(default_factory=dict)
 
 

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -43,6 +43,7 @@ class Scout:
     ) -> None:
         self.config = config or ScoutConfig()
         ct_inner = CTLogSource(self.config)
+        self._ct_inner = ct_inner
         rdap_inner = RDAPLookup(self.config)
         if cache is not None:
             from domain_scout.cache import CachedCTLogSource, CachedRDAPLookup
@@ -315,6 +316,16 @@ class Scout:
         # Build output
         domains = self._build_output(domain_evidence, seeds)
 
+        # Collect warnings (fallback observability)
+        warnings: list[str] = []
+        fb = self._ct_inner.json_fallback_count
+        if fb > 0:
+            q = "query" if fb == 1 else "queries"
+            warnings.append(
+                f"CT Postgres unavailable, used JSON fallback for {fb} {q}"
+                " (org-name matching degraded)"
+            )
+
         elapsed = time.monotonic() - t0
         run_meta = RunMetadata(
             tool_version=_pkg_version("domain-scout-ct"),
@@ -324,6 +335,7 @@ class Scout:
             timed_out=timed_out,
             seed_count=len(seeds),
             errors=errors,
+            warnings=warnings,
             config=self.config.to_dict(),
         )
         return ScoutResult(

--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -167,6 +167,7 @@ class CTLogSource:
     def __init__(self, config: ScoutConfig) -> None:
         self._cfg = config
         self._semaphore = asyncio.Semaphore(config.max_concurrent_queries)
+        self.json_fallback_count: int = 0
         # Lazily init shared breaker with first instance's config
         if CTLogSource._breaker is None:
             CTLogSource._breaker = _CircuitBreaker(
@@ -353,6 +354,7 @@ class CTLogSource:
         last_pg_error: Exception | None,
     ) -> list[dict[str, object]]:
         """Fall back to JSON API after Postgres failure or circuit breaker skip."""
+        self.json_fallback_count += 1
         if last_pg_error is not None:
             log.warning("ct.pg_failed_falling_back_to_json", error=str(last_pg_error))
         try:

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 from domain_scout.api import ScanRequest, create_app, get_app
 from domain_scout.models import EntityInput, RunMetadata, ScoutResult
+from domain_scout.sources.ct_logs import CTLogSource
 
 
 @pytest.fixture
@@ -75,6 +76,13 @@ class TestHealth:
 
 
 class TestReady:
+    @pytest.fixture(autouse=True)
+    def _reset_breaker(self) -> Iterator[None]:
+        old = CTLogSource._breaker
+        CTLogSource._breaker = None
+        yield
+        CTLogSource._breaker = old
+
     def test_ready_ok(self, client: TestClient) -> None:
         """Ready endpoint returns 'ready' when crt.sh probe succeeds."""
         with patch("domain_scout.api.httpx.AsyncClient", return_value=_mock_httpx_client()):
@@ -84,6 +92,7 @@ class TestReady:
         assert data["status"] == "ready"
         assert "version" in data
         assert data["details"]["crt_sh"] == "ok"
+        assert data["details"]["crt_sh_postgres_circuit_breaker"] == "unknown"
 
     def test_ready_degraded(self, client: TestClient) -> None:
         """Ready endpoint returns 'degraded' when crt.sh probe fails."""
@@ -94,6 +103,33 @@ class TestReady:
         data = resp.json()
         assert data["status"] == "degraded"
         assert data["details"]["crt_sh"] == "unreachable"
+
+    def test_ready_breaker_open_degraded(self, client: TestClient) -> None:
+        """Ready endpoint returns 'degraded' when circuit breaker is open."""
+        from domain_scout.sources.ct_logs import _CircuitBreaker
+
+        breaker = _CircuitBreaker(failure_threshold=1, recovery_timeout=60.0)
+        breaker.record_failure()
+        assert breaker.state == "open"
+        CTLogSource._breaker = breaker
+
+        with patch("domain_scout.api.httpx.AsyncClient", return_value=_mock_httpx_client()):
+            resp = client.get("/ready")
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["details"]["crt_sh_postgres_circuit_breaker"] == "open"
+
+    def test_ready_breaker_closed(self, client: TestClient) -> None:
+        """Ready endpoint shows closed breaker state."""
+        from domain_scout.sources.ct_logs import _CircuitBreaker
+
+        CTLogSource._breaker = _CircuitBreaker(failure_threshold=3, recovery_timeout=30.0)
+
+        with patch("domain_scout.api.httpx.AsyncClient", return_value=_mock_httpx_client()):
+            resp = client.get("/ready")
+        data = resp.json()
+        assert data["status"] == "ready"
+        assert data["details"]["crt_sh_postgres_circuit_breaker"] == "closed"
 
 
 class TestScan:

--- a/domain_scout/tests/test_ct.py
+++ b/domain_scout/tests/test_ct.py
@@ -393,6 +393,71 @@ class TestCircuitBreakerWiring:
         assert not pg_called  # breaker prevented the call
 
 
+class TestJsonFallbackCount:
+    """Test json_fallback_count increments on CTLogSource."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_breaker(self) -> Iterator[None]:
+        CTLogSource._breaker = None
+        yield
+        CTLogSource._breaker = None
+
+    @pytest.mark.asyncio
+    async def test_count_increments_on_pg_failure(self) -> None:
+        """json_fallback_count increments when PG fails and JSON fallback is used."""
+        config = ScoutConfig(postgres_max_retries=1, burst_delay=0.0)
+        ct = CTLogSource(config)
+        assert ct.json_fallback_count == 0
+
+        mock_json = _make_httpx_mock([{"id": 1, "common_name": "x.com", "name_value": "x.com"}])
+
+        async def failing_pg(term: str) -> list[dict[str, object]]:
+            raise ConnectionError("pg down")
+
+        with (
+            patch.object(ct, "_pg_query", side_effect=failing_pg),
+            patch("domain_scout.sources.ct_logs.httpx.AsyncClient", return_value=mock_json),
+        ):
+            await ct._pg_query_with_fallback("test")
+            assert ct.json_fallback_count == 1
+            await ct._pg_query_with_fallback("test2")
+            assert ct.json_fallback_count == 2
+
+    @pytest.mark.asyncio
+    async def test_count_increments_on_breaker_skip(self) -> None:
+        """json_fallback_count increments when circuit breaker skips PG."""
+        config = ScoutConfig(cb_failure_threshold=1, postgres_max_retries=1, burst_delay=0.0)
+        ct = CTLogSource(config)
+        mock_json = _make_httpx_mock([{"id": 1, "common_name": "x.com", "name_value": "x.com"}])
+
+        async def failing_pg(term: str) -> list[dict[str, object]]:
+            raise ConnectionError("pg down")
+
+        with (
+            patch.object(ct, "_pg_query", side_effect=failing_pg),
+            patch("domain_scout.sources.ct_logs.httpx.AsyncClient", return_value=mock_json),
+        ):
+            # Trip the breaker
+            await ct._pg_query_with_fallback("test")
+            assert ct.json_fallback_count == 1
+            # Breaker is open, skips PG
+            await ct._pg_query_with_fallback("test2")
+            assert ct.json_fallback_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_increment_on_pg_success(self) -> None:
+        """json_fallback_count stays 0 when PG succeeds."""
+        config = ScoutConfig()
+        ct = CTLogSource(config)
+
+        async def ok_pg(term: str) -> list[dict[str, object]]:
+            return [{"cert_id": 1, "common_name": "ok.com", "san_dns_names": []}]
+
+        with patch.object(ct, "_pg_query", side_effect=ok_pg):
+            await ct._pg_query_with_fallback("test")
+            assert ct.json_fallback_count == 0
+
+
 class TestPropertyBased:
     """Property-based tests using hypothesis."""
 

--- a/domain_scout/tests/test_delta.py
+++ b/domain_scout/tests/test_delta.py
@@ -51,6 +51,7 @@ def _make_result(
     timed_out: bool = False,
     config: dict[str, object] | None = None,
     schema_version: str = "1.0",
+    warnings: list[str] | None = None,
 ) -> ScoutResult:
     return ScoutResult(
         entity=EntityInput(
@@ -65,6 +66,7 @@ def _make_result(
             elapsed_seconds=5.0,
             domains_found=len(domains) if domains else 0,
             timed_out=timed_out,
+            warnings=warnings or [],
             config=config or {"total_timeout": 120},
         ),
     )
@@ -289,6 +291,44 @@ class TestDeltaWarnings:
         )
         codes = [w.code for w in result.warnings]
         assert "schema_version_mismatch" in codes
+
+    def test_ct_fallback_asymmetry_baseline_only(self) -> None:
+        fb_warn = [
+            "CT Postgres unavailable, used JSON fallback for 2 queries (org-name matching degraded)"
+        ]
+        result = compute_delta(
+            _make_result(warnings=fb_warn),
+            _make_result(),
+        )
+        codes = [w.code for w in result.warnings]
+        assert "ct_fallback_asymmetry" in codes
+
+    def test_ct_fallback_asymmetry_current_only(self) -> None:
+        fb_warn = [
+            "CT Postgres unavailable, used JSON fallback for 1 query (org-name matching degraded)"
+        ]
+        result = compute_delta(
+            _make_result(),
+            _make_result(warnings=fb_warn),
+        )
+        codes = [w.code for w in result.warnings]
+        assert "ct_fallback_asymmetry" in codes
+
+    def test_ct_fallback_asymmetry_both_no_warning(self) -> None:
+        fb_warn = [
+            "CT Postgres unavailable, used JSON fallback for 1 query (org-name matching degraded)"
+        ]
+        result = compute_delta(
+            _make_result(warnings=fb_warn),
+            _make_result(warnings=fb_warn),
+        )
+        codes = [w.code for w in result.warnings]
+        assert "ct_fallback_asymmetry" not in codes
+
+    def test_ct_fallback_asymmetry_neither_no_warning(self) -> None:
+        result = compute_delta(_make_result(), _make_result())
+        codes = [w.code for w in result.warnings]
+        assert "ct_fallback_asymmetry" not in codes
 
 
 # --- TestDeltaSerialization ---


### PR DESCRIPTION
## Summary
- Track JSON fallback usage via `CTLogSource.json_fallback_count` and surface warnings in `RunMetadata.warnings`
- CLI prints warnings to stderr; delta reporting detects `ct_fallback_asymmetry` between scans
- `/ready` endpoint exposes `crt_sh_postgres_circuit_breaker` state and returns `degraded` when breaker is open

## Test plan
- [x] 302 unit tests pass (9 new: 3 fallback counter, 4 delta asymmetry, 2 /ready breaker)
- [x] mypy --strict clean, ruff clean
- [x] Live tested with Stripe Inc (PG up → no warnings) and Cloudflare Inc (PG failed → warning surfaced)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)