### PR TITLE
Optimize seed validation and avoid redundant CT queries

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -110,6 +110,7 @@ class Scout:
         seed_assessments: dict[str, str] = {}
         seed_org_names: dict[str, str | None] = {}
         seed_cross_verification: dict[str, list[str]] = {}
+        seed_ct_records: dict[str, list[dict[str, Any]] | None] = {}
 
         independent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
 
@@ -153,6 +154,7 @@ class Scout:
                         seed_org_names[sd] = result["org_name"]
                         if result.get("co_hosted_seeds"):
                             seed_cross_verification[sd] = result["co_hosted_seeds"]
+                        seed_ct_records[sd] = result.get("ct_records")
                         log.info(
                             "scout.seed_validated",
                             seed=sd,
@@ -178,6 +180,7 @@ class Scout:
                             seed_org_names.setdefault(sd, r["org_name"])
                             if r.get("co_hosted_seeds"):
                                 seed_cross_verification.setdefault(sd, r["co_hosted_seeds"])
+                            seed_ct_records.setdefault(sd, r.get("ct_records"))
 
         # Phase 2: Seed-dependent strategies (B + optional second org search)
         dependent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
@@ -202,7 +205,7 @@ class Scout:
         for sd in seeds:
             dependent_tasks.append(
                 asyncio.create_task(
-                    self._strategy_seed_expansion(sd, entity.company_name, errors),
+                    self._strategy_seed_expansion(sd, entity.company_name, errors, seed_ct_records.get(sd)),
                     name=f"seed_expansion:{sd}",
                 )
             )
@@ -340,16 +343,20 @@ class Scout:
         self, seed: str, company_name: str, all_seeds: list[str], errors: list[str]
     ) -> dict[str, Any]:
         """Returns dict with assessment, org_name, and co_hosted_seeds."""
-        resolves = await self._dns.resolves(seed)
 
-        rdap_org: str | None = None
-        try:
-            rdap_org = await self._rdap.get_registrant_org(seed)
-        except Exception as exc:
-            errors.append(f"RDAP lookup failed for {seed}: {exc}")
+        async def _check_rdap() -> str | None:
+            try:
+                return await self._rdap.get_registrant_org(seed)
+            except Exception as exc:
+                errors.append(f"RDAP lookup failed for {seed}: {exc}")
+                return None
 
-        # Also check CT for the org name on certs
-        ct_records = await self._ct.search_by_domain(seed)
+        resolves, rdap_org, ct_records = await asyncio.gather(
+            self._dns.resolves(seed),
+            _check_rdap(),
+            self._ct.search_by_domain(seed),
+        )
+
         cert_orgs: set[str] = set()
         # Build reverse lookup: base domain -> original seed domain (excluding current seed)
         co_hosted_seeds: list[str] = []
@@ -408,6 +415,7 @@ class Scout:
             "assessment": assessment,
             "org_name": best_org,
             "co_hosted_seeds": co_hosted_seeds,
+            "ct_records": ct_records,
         }
 
     # --- Step 2A: Organization name search ---
@@ -465,14 +473,21 @@ class Scout:
     # --- Step 2B: Seed domain expansion ---
 
     async def _strategy_seed_expansion(
-        self, seed_domain: str, company_name: str, errors: list[str]
+        self,
+        seed_domain: str,
+        company_name: str,
+        errors: list[str],
+        ct_records: list[dict[str, object]] | None = None,
     ) -> list[tuple[str, _DomainAccum]]:
         results: list[tuple[str, _DomainAccum]] = []
-        try:
-            records = await self._ct.search_by_domain(seed_domain)
-        except Exception as exc:
-            errors.append(f"CT seed expansion failed: {exc}")
-            return results
+        if ct_records is not None:
+            records = ct_records
+        else:
+            try:
+                records = await self._ct.search_by_domain(seed_domain)
+            except Exception as exc:
+                errors.append(f"CT seed expansion failed: {exc}")
+                return results
 
         seed_base = extract_base_domain(seed_domain)
 


### PR DESCRIPTION
This change optimizes the `_validate_seed` method in `domain_scout/scout.py` to run DNS, RDAP, and CT queries concurrently. It also updates `_discover` to capture the CT records fetched during seed validation and pass them to `_strategy_seed_expansion`, eliminating a redundant call to the CT log source for the same seed domain.


---
*PR created automatically by Jules for task [3324233222863707467](https://jules.google.com/task/3324233222863707467) started by @minghsuy*