### PR TITLE
🧹 Refactor duplicated optional dependency check in CLI

### DIFF
--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -13,6 +13,7 @@ from domain_scout.config import ScoutConfig
 from domain_scout.scout import Scout
 
 if TYPE_CHECKING:
+    from domain_scout.cache import DuckDBCache
     from domain_scout.models import DeltaReport, ScoutResult
 
 app = typer.Typer(
@@ -68,9 +69,7 @@ def scout(
 
     cache = None
     if use_cache:
-        from domain_scout.cache import DuckDBCache
-
-        cache = DuckDBCache(cache_dir=cache_dir)
+        cache = _get_cache_or_exit(cache_dir)
 
     try:
         s = Scout(config=config, cache=cache)
@@ -159,6 +158,20 @@ def diff(
         _print_delta_table(report)
 
 
+def _get_cache_or_exit(cache_dir: str | Path | None = None) -> DuckDBCache:
+    """Import and instantiate DuckDBCache, or exit with a friendly error."""
+    try:
+        from domain_scout.cache import DuckDBCache
+
+        return DuckDBCache(cache_dir=cache_dir)
+    except ImportError:
+        typer.echo(
+            "Error: duckdb is not installed. Install with: pip install domain-scout-ct[cache]",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+
+
 def _load_result(path: Path, label: str) -> ScoutResult:
     """Load and validate a ScoutResult JSON file, or exit with an error."""
     from domain_scout.models import ScoutResult
@@ -230,16 +243,7 @@ def cache_stats(
 ) -> None:
     """Show cache statistics."""
     try:
-        from domain_scout.cache import DuckDBCache
-    except ImportError:
-        typer.echo(
-            "Error: duckdb is not installed. Install with: pip install domain-scout-ct[cache]",
-            err=True,
-        )
-        raise typer.Exit(1) from None
-
-    try:
-        with DuckDBCache(cache_dir=cache_dir) as cache:
+        with _get_cache_or_exit(cache_dir) as cache:
             stats = cache.stats()
     except Exception as exc:
         if "lock" in str(exc).lower():
@@ -266,16 +270,7 @@ def cache_clear(
 ) -> None:
     """Clear all cached entries."""
     try:
-        from domain_scout.cache import DuckDBCache
-    except ImportError:
-        typer.echo(
-            "Error: duckdb is not installed. Install with: pip install domain-scout-ct[cache]",
-            err=True,
-        )
-        raise typer.Exit(1) from None
-
-    try:
-        with DuckDBCache(cache_dir=cache_dir) as cache:
+        with _get_cache_or_exit(cache_dir) as cache:
             cache.clear()
     except Exception as exc:
         if "lock" in str(exc).lower():


### PR DESCRIPTION
This change refactors the duplicated optional dependency check for `DuckDBCache` in `domain_scout/cli.py` into a centralized helper function. This improves maintainability by reducing code duplication and ensuring consistent error handling across all CLI commands that interact with the cache.

🎯 **What:** The duplicated `try...except ImportError` logic for checking the `duckdb` optional dependency and instantiating `DuckDBCache` was refactored into a reusable private helper function `_get_cache_or_exit`.

💡 **Why:** Refactoring this logic into a helper function improves readability and maintainability. It also ensures that the `scout` command now provides a friendly error message when `duckdb` is missing, consistent with the `cache` commands.

✅ **Verification:**
- Performed static analysis and verified the code visually.
- Confirmed successful compilation of the modified file using `py_compile`.
- Addresssed code review feedback by removing temporary development scripts.
- Verified that existing exception handling (e.g., for database locks) remains functional.

✨ **Result:** Reduced duplication in `cli.py` and improved consistency in error handling for optional dependencies.

---
*PR created automatically by Jules for task [12708515443065180404](https://jules.google.com/task/12708515443065180404) started by @minghsuy*