### PR TITLE
Fix fragile X.509 subject parsing in CT logs

### DIFF
--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -56,10 +56,52 @@ def _parse_dt(value: object) -> datetime | None:
 
 
 def _extract_org_from_subject(subject: str) -> str | None:
-    """Parse O=... from an X.509 subject string."""
-    m = re.search(r"O=([^,]+)", subject)
-    if m:
-        return m.group(1).strip().strip('"')
+    """Parse O=... from an X.509 subject string.
+
+    Handles quoted strings with commas and escaped characters.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    in_quote = False
+    escape = False
+
+    # Split by comma, respecting quotes
+    for char in subject:
+        if escape:
+            current.append(char)
+            escape = False
+        elif char == "\\":
+            current.append(char)
+            escape = True
+        elif char == '"':
+            in_quote = not in_quote
+            current.append(char)
+        elif char == "," and not in_quote:
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current).strip())
+
+    for part in parts:
+        # Split on first = (key=value)
+        idx = part.find("=")
+        if idx == -1:
+            continue
+
+        key = part[:idx].strip().upper()
+        val = part[idx + 1 :].strip()
+
+        if key == "O":
+            # If quoted
+            if val.startswith('"') and val.endswith('"'):
+                inner = val[1:-1]
+                # In quoted string, \" is literal ", \\ is literal \
+                return inner.replace(r'\"', '"').replace(r"\\", "\\")
+
+            # Unquoted: unescape \, and \\
+            return val.replace(r"\,", ",").replace(r"\\", "\\")
+
     return None
 
 

--- a/domain_scout/tests/test_ct.py
+++ b/domain_scout/tests/test_ct.py
@@ -17,6 +17,7 @@ from domain_scout.config import ScoutConfig
 from domain_scout.sources.ct_logs import (
     CTLogSource,
     _CircuitBreaker,
+    _extract_org_from_subject,
     extract_base_domain,
     is_valid_domain,
 )
@@ -34,6 +35,46 @@ def _make_httpx_mock(json_payload: list[dict[str, object]]) -> AsyncMock:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     return mock_client
+
+
+class TestExtractOrgFromSubject:
+    def test_simple(self) -> None:
+        assert _extract_org_from_subject("O=Foo") == "Foo"
+
+    def test_with_other_attributes(self) -> None:
+        assert (
+            _extract_org_from_subject("C=US, O=Example Inc, CN=example.com") == "Example Inc"
+        )
+
+    def test_quoted_comma(self) -> None:
+        assert (
+            _extract_org_from_subject('C=US, O="Example, Inc.", CN=example.com')
+            == "Example, Inc."
+        )
+
+    def test_escaped_quotes(self) -> None:
+        assert (
+            _extract_org_from_subject(r'O="Org with \"quotes\""') == 'Org with "quotes"'
+        )
+
+    def test_escaped_comma_unquoted(self) -> None:
+        assert _extract_org_from_subject(r"O=ACME\, Inc., C=US") == "ACME, Inc."
+
+    def test_spaces_around_equals(self) -> None:
+        assert _extract_org_from_subject("O = Spaced Org, C=US") == "Spaced Org"
+
+    def test_multiple_attributes(self) -> None:
+        assert _extract_org_from_subject("CN=example.com, O=MyOrg") == "MyOrg"
+
+    def test_edge_case_o_in_value(self) -> None:
+        # "O=" appears inside the common name, should not confuse the parser
+        assert _extract_org_from_subject('CN="O=Fake", O=RealOrg') == "RealOrg"
+
+    def test_not_found(self) -> None:
+        assert _extract_org_from_subject("CN=example.com") is None
+
+    def test_empty(self) -> None:
+        assert _extract_org_from_subject("") is None
 
 
 class TestExtractBaseDomain:


### PR DESCRIPTION
Replaced fragile regex in `_extract_org_from_subject` with a robust parser to correctly handle quoted commas and escaped characters in X.509 subject strings. Added unit tests to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [2159339269306288809](https://jules.google.com/task/2159339269306288809) started by @minghsuy*