### PR TITLE
🔒 Fix potential SSRF in RDAP lookup

### DIFF
--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -49,7 +49,16 @@ class RDAPLookup:
             "country": self._extract_country(data),
         }
 
+    def _validate_domain(self, domain: str) -> None:
+        """Validate domain to prevent SSRF and path traversal."""
+        if not domain or len(domain) > 253:
+            raise ValueError(f"Invalid domain length: {domain!r}")
+        # Prevent path traversal and URL control characters
+        if ".." in domain or any(c in domain for c in "/?#:@"):
+            raise ValueError(f"Invalid domain characters: {domain!r}")
+
     async def _query(self, domain: str) -> dict[str, object]:
+        self._validate_domain(domain)
         url = f"{_RDAP_BOOTSTRAP}{domain}"
         async with httpx.AsyncClient(
             timeout=self._cfg.http_timeout,

--- a/domain_scout/tests/test_rdap_security.py
+++ b/domain_scout/tests/test_rdap_security.py
@@ -1,0 +1,62 @@
+"""Security tests for RDAPLookup to prevent SSRF and path traversal."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from domain_scout.sources.rdap import RDAPLookup
+from domain_scout.config import ScoutConfig
+
+@pytest.fixture
+def rdap_lookup():
+    config = ScoutConfig()
+    return RDAPLookup(config)
+
+@pytest.mark.asyncio
+async def test_rdap_query_validates_domain_path_traversal(rdap_lookup):
+    """Ensure path traversal attempts raise ValueError in _query."""
+    malicious_domains = [
+        "../../etc/passwd",
+        "example.com/../../",
+        "../example.com",
+        "example.com/..",
+    ]
+
+    for domain in malicious_domains:
+        # We test _query directly because get_registrant_org suppresses exceptions
+        with pytest.raises(ValueError, match="Invalid domain"):
+            await rdap_lookup._query(domain)
+
+@pytest.mark.asyncio
+async def test_rdap_query_validates_domain_url_chars(rdap_lookup):
+    """Ensure URL control characters raise ValueError in _query."""
+    malicious_domains = [
+        "http://example.com",
+        "example.com?query=1",
+        "example.com#fragment",
+        "user:pass@example.com",
+        "example.com:80",
+    ]
+
+    for domain in malicious_domains:
+        with pytest.raises(ValueError, match="Invalid domain"):
+            await rdap_lookup._query(domain)
+
+@pytest.mark.asyncio
+async def test_rdap_query_valid_domain_passes(rdap_lookup):
+    """Ensure valid domains are processed correctly."""
+    valid_domains = [
+        "example.com",
+        "sub.example.com",
+        "example-domain.com",
+        "123.com",
+    ]
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        for domain in valid_domains:
+            await rdap_lookup.get_registrant_org(domain)
+
+        assert mock_get.call_count == len(valid_domains)


### PR DESCRIPTION
This PR addresses a security vulnerability where the `domain` parameter in `RDAPLookup` was interpolated directly into a URL without validation. This could allow an attacker to perform SSRF or path traversal attacks.

**Changes:**
- Implemented `_validate_domain` in `domain_scout/sources/rdap.py` to sanitize input.
- Added strict checks for path traversal sequences (`..`) and URL control characters.
- Added a new test file `domain_scout/tests/test_rdap_security.py` to verify the fix and prevent regression.

**Testing:**
- Verified with new security tests covering various attack vectors.
- Ran full test suite to ensure no regressions.


---
*PR created automatically by Jules for task [7630420006995671934](https://jules.google.com/task/7630420006995671934) started by @minghsuy*