### PR TITLE
🧪 [testing improvement] Test _extract_sans helper for robust extraction

### DIFF
--- a/domain_scout/tests/test_scout_internals.py
+++ b/domain_scout/tests/test_scout_internals.py
@@ -1,0 +1,28 @@
+"""Unit tests for internal scout functions."""
+
+from domain_scout.scout import _extract_sans
+
+
+def test_extract_sans_missing_key() -> None:
+    rec: dict[str, object] = {}
+    assert _extract_sans(rec) == []
+
+
+def test_extract_sans_none_value() -> None:
+    rec: dict[str, object] = {"san_dns_names": None}
+    assert _extract_sans(rec) == []
+
+
+def test_extract_sans_string_value() -> None:
+    rec: dict[str, object] = {"san_dns_names": "example.com"}
+    assert _extract_sans(rec) == []
+
+
+def test_extract_sans_list_of_strings() -> None:
+    rec: dict[str, object] = {"san_dns_names": ["example.com", "test.com"]}
+    assert _extract_sans(rec) == ["example.com", "test.com"]
+
+
+def test_extract_sans_empty_list() -> None:
+    rec: dict[str, object] = {"san_dns_names": []}
+    assert _extract_sans(rec) == []


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `_extract_sans` helper function in `domain_scout/scout.py`.

📊 **Coverage:** The new tests cover the following scenarios:
- Missing key (`san_dns_names` not present)
- `None` value for `san_dns_names`
- Non-list value (e.g., string) for `san_dns_names`
- Valid list of strings for `san_dns_names`
- Empty list for `san_dns_names`

✨ **Result:** The test coverage is improved by ensuring that `_extract_sans` correctly handles these various inputs without raising errors, ensuring robust extraction of SAN DNS names.

---
*PR created automatically by Jules for task [1678183010662348086](https://jules.google.com/task/1678183010662348086) started by @minghsuy*