### PR TITLE
🧹 remove unused CertRecord model and verify delta logic

### DIFF
--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -118,16 +118,3 @@ class DeltaReport(BaseModel):
     current_metadata: RunMetadata
 
 
-# --- Intermediate models (not part of public API) ---
-
-
-class CertRecord(BaseModel):
-    """A certificate record from crt.sh."""
-
-    cert_id: int
-    common_name: str
-    subject: str
-    org_name: str | None = None
-    not_before: datetime | None = None
-    not_after: datetime | None = None
-    san_dns_names: list[str] = Field(default_factory=list)


### PR DESCRIPTION
Identified and removed an unused intermediate model `CertRecord` in `domain_scout/models.py`. Also analyzed `domain_scout/delta.py` as requested and confirmed that the `_diff_domain` helper is essential for reporting field-level changes and its implementation is robust against unsorted input.

---
*PR created automatically by Jules for task [7351123716635870520](https://jules.google.com/task/7351123716635870520) started by @minghsuy*