### PR TITLE
🔒 Fix unbounded list size in seed_domain input

### DIFF
--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -12,7 +12,7 @@ class EntityInput(BaseModel):
 
     company_name: str = Field(min_length=1, max_length=200)
     location: str | None = None
-    seed_domain: list[str] = Field(default_factory=list)
+    seed_domain: list[str] = Field(default_factory=list, max_length=50)
     industry: str | None = None
 
 

--- a/domain_scout/tests/test_models.py
+++ b/domain_scout/tests/test_models.py
@@ -1,0 +1,23 @@
+from pydantic import ValidationError
+import pytest
+
+from domain_scout.models import EntityInput
+
+def test_entity_input_seed_domain_max_length():
+    # Valid input with 50 seed domains
+    try:
+        EntityInput(
+            company_name="Valid Company",
+            seed_domain=["example.com"] * 50
+        )
+    except ValidationError:
+        pytest.fail("ValidationError raised unexpectedly for 50 seed domains")
+
+    # Invalid input with 51 seed domains
+    with pytest.raises(ValidationError) as exc_info:
+        EntityInput(
+            company_name="Invalid Company",
+            seed_domain=["example.com"] * 51
+        )
+
+    assert "List should have at most 50 items after validation" in str(exc_info.value)


### PR DESCRIPTION
🎯 **What:** Bounded the `seed_domain` input array size by enforcing a maximum length of 50.
⚠️ **Risk:** Without a length constraint on `seed_domain`, an attacker or user could pass a massive list of seed domains, leading to an unbounded number of asynchronous tasks being created during the scanning process, which could overwhelm the server and cause a Denial of Service (DoS).
🛡️ **Solution:** Added `max_length=50` to the `seed_domain` Pydantic `Field` in `EntityInput`. This cleanly validates the list at the entry point of the API, securely rejecting excessive inputs before any processing occurs. Included a test case to guarantee the constraint operates as expected.

---
*PR created automatically by Jules for task [6865862924255159670](https://jules.google.com/task/6865862924255159670) started by @minghsuy*