### PR TITLE
🧹 Add `# noqa: PLR0913` to Typer CLI commands to suppress parameter warnings

### DIFF
--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -27,7 +27,7 @@ app.add_typer(cache_app, name="cache")
 
 
 @app.command()
-def scout(
+def scout(  # noqa: PLR0913
     name: Annotated[str, typer.Option("--name", "-n", help="Company name to search for")],
     location: Annotated[
         str | None, typer.Option("--location", "-l", help="City, state, country")
@@ -124,7 +124,7 @@ def scout(
 
 
 @app.command()
-def serve(
+def serve(  # noqa: PLR0913
     host: Annotated[str, typer.Option("--host", help="Bind address")] = "127.0.0.1",
     port: Annotated[int, typer.Option("--port", help="Bind port")] = 8080,
     workers: Annotated[int, typer.Option("--workers", help="Uvicorn workers")] = 1,


### PR DESCRIPTION
🎯 **What:** Suppressed the "too many arguments" (`PLR0913`) linter warning in the `scout` and `serve` Typer CLI commands.
💡 **Why:** Typer explicitly requires parameters in the function signature to map CLI options and arguments. Refactoring these parameters into a configuration object (as normally suggested for standard functions) would break the CLI interface. Suppressing the warning acknowledges this framework-specific requirement while keeping the CI/CD pipeline green.
✅ **Verification:** Ran `uv run ruff check --select PLR0913 domain_scout/cli.py` to confirm the linter errors were resolved and executed `uv run --all-extras pytest domain_scout/tests -m "not integration" -v` to ensure the application continues to function as expected.
✨ **Result:** Clean linter output without breaking CLI functionality.

---
*PR created automatically by Jules for task [8927338882260854634](https://jules.google.com/task/8927338882260854634) started by @minghsuy*