### PR TITLE
🧹 Suppress PLR0913 for Typer CLI commands in domain_scout/cli.py

### DIFF
--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -27,7 +27,7 @@ app.add_typer(cache_app, name="cache")
 
 
 @app.command()
-def scout(
+def scout(  # noqa: PLR0913
     name: Annotated[str, typer.Option("--name", "-n", help="Company name to search for")],
     location: Annotated[
         str | None, typer.Option("--location", "-l", help="City, state, country")
@@ -124,7 +124,7 @@ def scout(
 
 
 @app.command()
-def serve(
+def serve(  # noqa: PLR0913
     host: Annotated[str, typer.Option("--host", help="Bind address")] = "127.0.0.1",
     port: Annotated[int, typer.Option("--port", help="Bind port")] = 8080,
     workers: Annotated[int, typer.Option("--workers", help="Uvicorn workers")] = 1,


### PR DESCRIPTION
🎯 **What:** Suppressed the `PLR0913` (too many arguments) linter warning on the `scout` and `serve` commands in `domain_scout/cli.py`.
💡 **Why:** `Typer` relies on the explicit function signature to dynamically generate CLI options and help text. Refactoring these parameters into a configuration object or using `**kwargs` breaks Typer's core functionality, as it does not natively support dataclasses for arguments without experimental plugins. Suppressing the rule locally is the standard framework-aware approach.
✅ **Verification:** Ran `uv run ruff check domain_scout/cli.py` to confirm the linter warning is resolved. Ran `uv run --all-extras pytest domain_scout/tests/test_cli.py` to ensure CLI functionality and testing is preserved.
✨ **Result:** Code health metrics are improved without breaking the CLI interface or requiring heavy workarounds.

---
*PR created automatically by Jules for task [4457516145957574805](https://jules.google.com/task/4457516145957574805) started by @minghsuy*