### PR TITLE
🔒 fix: Add API key authentication to FastAPI endpoints

### DIFF
--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import secrets
 import time
 from contextlib import asynccontextmanager
 from importlib.metadata import version as _pkg_version
@@ -14,7 +15,8 @@ if TYPE_CHECKING:
 
 import httpx
 import structlog
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import Depends, FastAPI, HTTPException, Response, Security
+from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field
 
 from domain_scout._metrics import CONTENT_TYPE_LATEST, generate_latest
@@ -66,6 +68,7 @@ def create_app(
     *,
     cache: DuckDBCache | None = None,
     max_concurrent: int = 3,
+    api_key: str | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application."""
 
@@ -87,6 +90,19 @@ def create_app(
     app.state.semaphore = asyncio.Semaphore(max_concurrent)
     app.state.ready_cache = {}
     app.state.ready_cache_ts = 0.0
+    app.state.api_key = api_key
+
+    api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+    def verify_api_key(
+        api_key_header: str | None = Security(api_key_header),
+    ) -> None:
+        if app.state.api_key is None:
+            return
+        if not api_key_header:
+            raise HTTPException(status_code=401, detail="API Key required")
+        if not secrets.compare_digest(api_key_header, app.state.api_key):
+            raise HTTPException(status_code=401, detail="Invalid API Key")
 
     @app.get("/health")
     async def health() -> dict[str, str]:
@@ -118,7 +134,7 @@ def create_app(
         app.state.ready_cache_ts = now
         return result
 
-    @app.post("/scan", response_model=ScoutResult)
+    @app.post("/scan", response_model=ScoutResult, dependencies=[Depends(verify_api_key)])
     async def scan(req: ScanRequest) -> ScoutResult:
         """Run a domain discovery scan."""
         overrides: dict[str, Any] = {}
@@ -160,7 +176,7 @@ def create_app(
 
         return result
 
-    @app.get("/cache/stats")
+    @app.get("/cache/stats", dependencies=[Depends(verify_api_key)])
     async def cache_stats() -> dict[str, Any]:
         """Return cache statistics."""
         if app.state.cache is None:
@@ -169,7 +185,7 @@ def create_app(
         stats = await loop.run_in_executor(None, app.state.cache.stats)
         return {"enabled": True, **stats}
 
-    @app.post("/cache/clear")
+    @app.post("/cache/clear", dependencies=[Depends(verify_api_key)])
     async def cache_clear() -> dict[str, str]:
         """Clear all cached entries."""
         if app.state.cache is None:
@@ -180,7 +196,7 @@ def create_app(
 
     # No semaphore needed: compute_delta is pure CPU, no network I/O,
     # sub-millisecond for typical result sizes (<100 domains).
-    @app.post("/diff", response_model=DeltaReport)
+    @app.post("/diff", response_model=DeltaReport, dependencies=[Depends(verify_api_key)])
     async def diff_endpoint(req: DiffRequest) -> DeltaReport:
         """Compute delta between two scan results."""
         return compute_delta(req.baseline, req.current)
@@ -209,4 +225,7 @@ def get_app() -> FastAPI:
 
     cache_dir = os.environ.get("DOMAIN_SCOUT_CACHE_DIR")
     cache = DuckDBCache(cache_dir=cache_dir) if cache_enabled else None
-    return create_app(cache=cache, max_concurrent=max_concurrent)
+
+    api_key = os.environ.get("DOMAIN_SCOUT_API_KEY")
+
+    return create_app(cache=cache, max_concurrent=max_concurrent, api_key=api_key)

--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -134,6 +134,9 @@ def serve(
     no_cache: Annotated[bool, typer.Option("--no-cache", help="Disable query cache")] = False,
     cache_dir: Annotated[str | None, typer.Option("--cache-dir", help="Cache directory")] = None,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Debug logging")] = False,
+    api_key: Annotated[
+        str | None, typer.Option("--api-key", help="API Key for authentication")
+    ] = None,
 ) -> None:
     """Start the REST API server."""
     import os
@@ -157,6 +160,8 @@ def serve(
         os.environ["DOMAIN_SCOUT_CACHE"] = "false"
     if cache_dir:
         os.environ["DOMAIN_SCOUT_CACHE_DIR"] = cache_dir
+    if api_key:
+        os.environ["DOMAIN_SCOUT_API_KEY"] = api_key
 
     uvicorn.run(
         "domain_scout.api:get_app",

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -241,3 +241,80 @@ class TestScanRequest:
         assert req.profile == "strict"
         assert req.timeout == 60
         assert req.deep is True
+
+
+class TestAPIKeyAuth:
+    @pytest.fixture
+    def auth_client(self) -> TestClient:
+        app = create_app(cache=None, max_concurrent=2, api_key="secret-key")
+        return TestClient(app)
+
+    def test_missing_api_key_unauthorized(self, auth_client: TestClient) -> None:
+        """Requests without API key return 401 on protected endpoints."""
+        resp = auth_client.post("/scan", json={"entity": {"company_name": "TestCorp"}})
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "API Key required"
+
+        resp = auth_client.get("/cache/stats")
+        assert resp.status_code == 401
+
+        resp = auth_client.post("/cache/clear")
+        assert resp.status_code == 401
+
+        import json
+
+        resp = auth_client.post(
+            "/diff",
+            json={
+                "baseline": json.loads(_mock_result().model_dump_json()),
+                "current": json.loads(_mock_result().model_dump_json()),
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_api_key_unauthorized(self, auth_client: TestClient) -> None:
+        """Requests with an invalid API key return 401."""
+        resp = auth_client.post(
+            "/scan",
+            json={"entity": {"company_name": "TestCorp"}},
+            headers={"X-API-Key": "wrong-key"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid API Key"
+
+    def test_valid_api_key_succeeds(
+        self, auth_client: TestClient, mock_discover: AsyncMock
+    ) -> None:
+        """Requests with a valid API key succeed."""
+        resp = auth_client.post(
+            "/scan",
+            json={"entity": {"company_name": "TestCorp"}},
+            headers={"X-API-Key": "secret-key"},
+        )
+        assert resp.status_code == 200
+
+        resp = auth_client.get("/cache/stats", headers={"X-API-Key": "secret-key"})
+        assert resp.status_code == 200
+
+        import json
+
+        resp = auth_client.post(
+            "/diff",
+            json={
+                "baseline": json.loads(_mock_result().model_dump_json()),
+                "current": json.loads(_mock_result().model_dump_json()),
+            },
+            headers={"X-API-Key": "secret-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_public_endpoints_unaffected(self, auth_client: TestClient) -> None:
+        """Endpoints like /health and /ready remain accessible without a key."""
+        resp = auth_client.get("/health")
+        assert resp.status_code == 200
+
+        # Note: /ready relies on HTTPX client inside which might fail depending on external logic,
+        # so we mock the httpx client here as well.
+        with patch("domain_scout.api.httpx.AsyncClient", return_value=_mock_httpx_client()):
+            resp = auth_client.get("/ready")
+        assert resp.status_code == 200


### PR DESCRIPTION
🎯 **What:** 
The vulnerability fixed was the missing authentication mechanism on sensitive API endpoints (`/scan`, `/cache/stats`, `/cache/clear`, `/diff`). A user could trigger long-running scans or clear caches unconditionally without prior authentication if deployed as a public service.

⚠️ **Risk:** 
If left unfixed, deploying the API would expose internal scanning capabilities and application caches to any user on the Internet. An attacker could exploit these public endpoints to perform Denial of Service (DoS) attacks, exhaust system resources or cache quotas, or retrieve cached reconnaissance data.

🛡️ **Solution:** 
This PR introduces API Key authentication utilizing FastAPI's `Security` and `APIKeyHeader`. An optional `api_key` argument has been added to the `serve` CLI command (and the corresponding `DOMAIN_SCOUT_API_KEY` environment variable). The key is injected into `app.state` upon application startup.
Sensitive endpoints are guarded by a dependency (`verify_api_key`) that securely compares the incoming `X-API-Key` header with the configured API key using `secrets.compare_digest` to prevent timing attacks. Public utility endpoints like `/health` and `/ready` remain unauthenticated by design.

---
*PR created automatically by Jules for task [10933116211275320067](https://jules.google.com/task/10933116211275320067) started by @minghsuy*