### PR TITLE
🧹 [refactor: reduce nesting in `_infra_boost`]

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -960,18 +960,19 @@ class Scout:
         async def _check(domain: str, accum: _DomainAccum) -> None:
             try:
                 shared = await self._dns.shares_infrastructure(reference, domain)
-                if shared:
-                    accum.sources.add("shared_infra")
-                    accum.evidence.append(
-                        EvidenceRecord(
-                            source_type="shared_infra",
-                            description=f"Shares infrastructure with {reference}",
-                        )
+                if not shared:
+                    return
+                accum.sources.add("shared_infra")
+                accum.evidence.append(
+                    EvidenceRecord(
+                        source_type="shared_infra",
+                        description=f"Shares infrastructure with {reference}",
                     )
-                    # Cap so infra boost can't exceed the +0.10 total boost limit.
-                    # Only cross_seed_verified (0.90 base) should reach 1.00.
-                    max_conf = 1.0 if "cross_seed_verified" in accum.sources else 0.95
-                    accum.confidence = round(min(max_conf, accum.confidence + 0.05), 2)
+                )
+                # Cap so infra boost can't exceed the +0.10 total boost limit.
+                # Only cross_seed_verified (0.90 base) should reach 1.00.
+                max_conf = 1.0 if "cross_seed_verified" in accum.sources else 0.95
+                accum.confidence = round(min(max_conf, accum.confidence + 0.05), 2)
             except Exception:
                 pass
 


### PR DESCRIPTION
🎯 **What:** Flattened deeply nested conditional logic within the `_infra_boost` internal `_check` async function.
💡 **Why:** By replacing a nested `if shared:` block with an early return (`if not shared: return`), the core logic inside the `_check` function is unindented by one level. This improves overall readability and code maintainability, and follows the common python idiom of returning early to reduce cognitive load.
✅ **Verification:** Ran `uv run --all-extras pytest` to confirm that all 452 existing tests, including tests related to `domain_scout/scout.py` and overall application integration, passed successfully without any regressions. The logic structure maintains the exact identical runtime behavior.
✨ **Result:** Improved code health and readability in `domain_scout/scout.py` while safely preserving functionality.

---
*PR created automatically by Jules for task [12985032443476189461](https://jules.google.com/task/12985032443476189461) started by @minghsuy*