### PR TITLE
🧹 [code health improvement] Flatten deeply nested code in _rdap_corroborate

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -985,6 +985,30 @@ class Scout:
 
     # --- RDAP corroboration ---
 
+    async def _check_rdap_candidate(
+        self, domain: str, accum: _DomainAccum, company_name: str
+    ) -> None:
+        try:
+            rdap_org = await self._rdap.get_registrant_org(domain)
+            if not rdap_org:
+                return
+            sim = org_name_similarity(rdap_org, company_name)
+            if sim < self.config.org_match_threshold:
+                return
+
+            accum.sources.add("rdap_registrant_match")
+            accum.rdap_org = rdap_org
+            accum.evidence.append(
+                EvidenceRecord(
+                    source_type="rdap_registrant_match",
+                    description=f"RDAP registrant '{rdap_org}' matches target (score={sim:.2f})",
+                    rdap_org=rdap_org,
+                    similarity_score=round(sim, 4),
+                )
+            )
+        except Exception as exc:
+            log.debug("scout.rdap_corroborate_error", domain=domain, error=str(exc))
+
     async def _rdap_corroborate(
         self, domain_evidence: dict[str, _DomainAccum], company_name: str
     ) -> None:
@@ -1002,31 +1026,11 @@ class Scout:
         if not candidates:
             return
 
-        async def _check(domain: str, accum: _DomainAccum) -> None:
-            try:
-                rdap_org = await self._rdap.get_registrant_org(domain)
-                if not rdap_org:
-                    return
-                sim = org_name_similarity(rdap_org, company_name)
-                if sim >= self.config.org_match_threshold:
-                    accum.sources.add("rdap_registrant_match")
-                    accum.rdap_org = rdap_org
-                    accum.evidence.append(
-                        EvidenceRecord(
-                            source_type="rdap_registrant_match",
-                            description=(
-                                f"RDAP registrant '{rdap_org}' matches target (score={sim:.2f})"
-                            ),
-                            rdap_org=rdap_org,
-                            similarity_score=round(sim, 4),
-                        )
-                    )
-            except Exception as exc:
-                log.debug("scout.rdap_corroborate_error", domain=domain, error=str(exc))
-
         try:
             await asyncio.wait_for(
-                asyncio.gather(*[_check(d, a) for d, a in candidates]),
+                asyncio.gather(
+                    *[self._check_rdap_candidate(d, a, company_name) for d, a in candidates]
+                ),
                 timeout=15.0,
             )
         except TimeoutError:


### PR DESCRIPTION
🎯 **What:** Extracted the inner `_check` function inside `_rdap_corroborate` (in `domain_scout/scout.py`) into a private instance method `_check_rdap_candidate` and flattened its nested logic by using early returns.
💡 **Why:** The previous code had a deeply nested condition to check the RDAP registrant match threshold, making the async `_check` closure harder to read and maintain. Refactoring it into an instance method and applying the guard-clause pattern flattens the code and improves readability without altering functionality.
✅ **Verification:** Ran `uv run pytest domain_scout/tests` and `uv run ruff check domain_scout` to ensure all functionality is preserved and no linting issues were introduced. The automated code review also evaluated the patch as safe and correct.
✨ **Result:** A cleaner, flatter structure in `_rdap_corroborate` that adheres to better code health standards while perfectly preserving its functionality.

---
*PR created automatically by Jules for task [14970125618022228257](https://jules.google.com/task/14970125618022228257) started by @minghsuy*