### PR TITLE
🧹 [code health] Flatten deeply nested conditionals in Scout._check functions

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -960,18 +960,19 @@ class Scout:
         async def _check(domain: str, accum: _DomainAccum) -> None:
             try:
                 shared = await self._dns.shares_infrastructure(reference, domain)
-                if shared:
-                    accum.sources.add("shared_infra")
-                    accum.evidence.append(
-                        EvidenceRecord(
-                            source_type="shared_infra",
-                            description=f"Shares infrastructure with {reference}",
-                        )
+                if not shared:
+                    return
+                accum.sources.add("shared_infra")
+                accum.evidence.append(
+                    EvidenceRecord(
+                        source_type="shared_infra",
+                        description=f"Shares infrastructure with {reference}",
                     )
-                    # Cap so infra boost can't exceed the +0.10 total boost limit.
-                    # Only cross_seed_verified (0.90 base) should reach 1.00.
-                    max_conf = 1.0 if "cross_seed_verified" in accum.sources else 0.95
-                    accum.confidence = round(min(max_conf, accum.confidence + 0.05), 2)
+                )
+                # Cap so infra boost can't exceed the +0.10 total boost limit.
+                # Only cross_seed_verified (0.90 base) should reach 1.00.
+                max_conf = 1.0 if "cross_seed_verified" in accum.sources else 0.95
+                accum.confidence = round(min(max_conf, accum.confidence + 0.05), 2)
             except Exception:
                 pass
 
@@ -1008,19 +1009,20 @@ class Scout:
                 if not rdap_org:
                     return
                 sim = org_name_similarity(rdap_org, company_name)
-                if sim >= self.config.org_match_threshold:
-                    accum.sources.add("rdap_registrant_match")
-                    accum.rdap_org = rdap_org
-                    accum.evidence.append(
-                        EvidenceRecord(
-                            source_type="rdap_registrant_match",
-                            description=(
-                                f"RDAP registrant '{rdap_org}' matches target (score={sim:.2f})"
-                            ),
-                            rdap_org=rdap_org,
-                            similarity_score=round(sim, 4),
-                        )
+                if sim < self.config.org_match_threshold:
+                    return
+                accum.sources.add("rdap_registrant_match")
+                accum.rdap_org = rdap_org
+                accum.evidence.append(
+                    EvidenceRecord(
+                        source_type="rdap_registrant_match",
+                        description=(
+                            f"RDAP registrant '{rdap_org}' matches target (score={sim:.2f})"
+                        ),
+                        rdap_org=rdap_org,
+                        similarity_score=round(sim, 4),
                     )
+                )
             except Exception as exc:
                 log.debug("scout.rdap_corroborate_error", domain=domain, error=str(exc))
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Deep nesting in the `_check` functions within `_rdap_corroborate` (line 1005) and `_infra_boost` (line 960) in `domain_scout/scout.py`.

💡 **Why:** How this improves maintainability
Flattening conditionals by returning early reduces indentation levels, making the logical flow much easier to follow and maintain, aligning with clean code practices.

✅ **Verification:** How you confirmed the change is safe
Ran the complete test suite using `uv run --all-extras pytest domain_scout/tests` which passed successfully, confirming no regressions in behavior. Code logic remains identical.

✨ **Result:** The improvement achieved
A flatter, cleaner, more readable implementation of `_check` that preserves all original functionality while improving code health.

---
*PR created automatically by Jules for task [8369747965523313813](https://jules.google.com/task/8369747965523313813) started by @minghsuy*