### PR TITLE
🧪 Add test for Scout._strategy_org_search error handling

### DIFF
--- a/domain_scout/tests/test_scout.py
+++ b/domain_scout/tests/test_scout.py
@@ -5,16 +5,36 @@ from unittest.mock import AsyncMock, patch
 
 from domain_scout.scout import Scout, SOURCE_ERRORS_TOTAL
 
+
 @pytest.mark.asyncio
-async def test_strategy_org_search_error_handling() -> None:
+@pytest.mark.parametrize(
+    "exc_class,exc_msg",
+    [
+        (Exception, "Database down"),
+        (TimeoutError, "Connection timed out"),
+        (ConnectionError, "Connection refused"),
+        (OSError, "Network unreachable"),
+    ],
+    ids=["generic", "timeout", "connection", "os"],
+)
+async def test_strategy_org_search_error_handling(
+    exc_class: type[Exception], exc_msg: str
+) -> None:
+    """_strategy_org_search must fail open: catch any exception, return empty
+    results, record the error message, and bump the Prometheus counter."""
     scout = Scout()
-    scout._ct.search_by_org = AsyncMock(side_effect=Exception("Database down"))
+    scout._ct.search_by_org = AsyncMock(side_effect=exc_class(exc_msg))  # type: ignore[method-assign]
 
     errors: list[str] = []
 
     with patch("domain_scout.scout.inc") as mock_inc:
         results = await scout._strategy_org_search("Test Org", errors)
 
-        assert results == []
-        assert errors == ["CT org search failed: Database down"]
-        mock_inc.assert_called_once_with(SOURCE_ERRORS_TOTAL, source="ct")
+    # Fails open — returns empty list, never raises
+    assert results == []
+    # Error message captured
+    assert len(errors) == 1
+    assert exc_msg in errors[0]
+    assert errors[0].startswith("CT org search failed: ")
+    # Prometheus counter incremented exactly once
+    mock_inc.assert_called_once_with(SOURCE_ERRORS_TOTAL, source="ct")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of explicit test coverage for the exception handling within `Scout._strategy_org_search` method. When an exception occurs during a CT org search, the code logs the error and increments a metric, but this path wasn't formally tested.

📊 **Coverage:** The new test, `test_strategy_org_search_error_handling` in `domain_scout/tests/test_scout.py`, now specifically tests the scenario where `self._ct.search_by_org` raises an exception. It verifies that the method returns an empty list, appends the correct error message to the `errors` list, and correctly increments the `SOURCE_ERRORS_TOTAL` Prometheus metric.

✨ **Result:** Test coverage is improved by validating the fail-open path and ensuring that source failures correctly feed into telemetry.

---
*PR created automatically by Jules for task [4324192442421220875](https://jules.google.com/task/4324192442421220875) started by @minghsuy*