### PR TITLE
Eliminate redundant DNS/CT queries and deduplicate test helpers

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -43,6 +43,7 @@ from domain_scout.sources.dns_utils import DNSChecker
 from domain_scout.sources.rdap import RDAPLookup
 
 log = structlog.get_logger()
+_TOOL_VERSION = _pkg_version("domain-scout-ct")
 
 
 def load_subsidiary_map(csv_path: str) -> dict[str, list[str]]:
@@ -305,6 +306,7 @@ class Scout:
         seed_assessments: dict[str, str] = {}
         seed_org_names: dict[str, str | None] = {}
         seed_cross_verification: dict[str, list[str]] = {}
+        seed_ct_records: dict[str, list[dict[str, Any]]] = {}
 
         independent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
 
@@ -366,6 +368,8 @@ class Scout:
                         seed_org_names[sd] = result["org_name"]
                         if result.get("co_hosted_seeds"):
                             seed_cross_verification[sd] = result["co_hosted_seeds"]
+                        if result.get("ct_records"):
+                            seed_ct_records[sd] = result["ct_records"]
                         log.info(
                             "scout.seed_validated",
                             seed=sd,
@@ -391,6 +395,8 @@ class Scout:
                             seed_org_names.setdefault(sd, r["org_name"])
                             if r.get("co_hosted_seeds"):
                                 seed_cross_verification.setdefault(sd, r["co_hosted_seeds"])
+                            if r.get("ct_records"):
+                                seed_ct_records.setdefault(sd, r["ct_records"])
 
         # Phase 2: Seed-dependent strategies (B + optional second org search)
         dependent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
@@ -411,11 +417,16 @@ class Scout:
                     )
                 )
 
-        # Strategy B per seed (parallel) — tagged with seed name
+        # Strategy B per seed (parallel) — reuses CT records from seed validation
         for sd in seeds:
             dependent_tasks.append(
                 asyncio.create_task(
-                    self._strategy_seed_expansion(sd, entity.company_name, errors),
+                    self._strategy_seed_expansion(
+                        sd,
+                        entity.company_name,
+                        errors,
+                        ct_records=seed_ct_records.get(sd),
+                    ),
                     name=f"seed_expansion:{sd}",
                 )
             )
@@ -542,7 +553,7 @@ class Scout:
         observe(DOMAINS_FOUND, float(len(domains)))
 
         run_meta = RunMetadata(
-            tool_version=_pkg_version("domain-scout-ct"),
+            tool_version=_TOOL_VERSION,
             timestamp=datetime.now(UTC),
             elapsed_seconds=round(elapsed, 2),
             domains_found=len(domains),
@@ -569,7 +580,7 @@ class Scout:
         errors: list[str],
         seed_to_base: dict[str, str | None] | None = None,
     ) -> dict[str, Any]:
-        """Returns dict with assessment, org_name, and co_hosted_seeds."""
+        """Returns dict with assessment, org_name, co_hosted_seeds, and ct_records."""
         resolves = await self._dns.resolves(seed)
 
         rdap_org: str | None = None
@@ -578,7 +589,7 @@ class Scout:
         except Exception as exc:
             errors.append(f"RDAP lookup failed for {seed}: {exc}")
 
-        # Also check CT for the org name on certs
+        # Also check CT for the org name on certs (shared with seed expansion)
         ct_records = await self._ct.search_by_domain(seed)
         cert_orgs: set[str] = set()
 
@@ -640,6 +651,7 @@ class Scout:
             "assessment": assessment,
             "org_name": best_org,
             "co_hosted_seeds": co_hosted_seeds,
+            "ct_records": ct_records,
         }
 
     # --- Step 2A: Organization name search ---
@@ -713,15 +725,22 @@ class Scout:
     # --- Step 2B: Seed domain expansion ---
 
     async def _strategy_seed_expansion(
-        self, seed_domain: str, company_name: str, errors: list[str]
+        self,
+        seed_domain: str,
+        company_name: str,
+        errors: list[str],
+        ct_records: list[dict[str, Any]] | None = None,
     ) -> list[tuple[str, _DomainAccum]]:
         results: list[tuple[str, _DomainAccum]] = []
-        try:
-            records = await self._ct.search_by_domain(seed_domain)
-        except Exception as exc:
-            inc(SOURCE_ERRORS_TOTAL, source="ct")
-            errors.append(f"CT seed expansion failed: {exc}")
-            return results
+        if ct_records is not None:
+            records = ct_records
+        else:
+            try:
+                records = await self._ct.search_by_domain(seed_domain)
+            except Exception as exc:
+                inc(SOURCE_ERRORS_TOTAL, source="ct")
+                errors.append(f"CT seed expansion failed: {exc}")
+                return results
 
         seed_base = extract_base_domain(seed_domain)
 
@@ -750,9 +769,7 @@ class Scout:
                 accum = _DomainAccum()
 
                 # Is this a SAN on a cert that also covers the seed domain?
-                has_seed_san = any(
-                    extract_base_domain(s) == seed_base for s in sans if is_valid_domain(s)
-                )
+                has_seed_san = seed_base in unique_bases
 
                 if base == seed_base:
                     accum.sources.add(f"ct_seed_subdomain:{seed_domain}")

--- a/domain_scout/sources/dns_utils.py
+++ b/domain_scout/sources/dns_utils.py
@@ -36,14 +36,10 @@ class DNSChecker:
 
     async def resolves(self, domain: str) -> bool:
         """Check whether a domain resolves to any A or AAAA record."""
-        for rdtype in (dns.rdatatype.A, dns.rdatatype.AAAA):
-            try:
-                await self._resolver.resolve(domain, rdtype)
-                return True
-            except (dns.exception.DNSException, ValueError):
-                continue
-        log.debug("dns.no_resolution", domain=domain)
-        return False
+        ips = await self.get_ips(domain)
+        if not ips:
+            log.debug("dns.no_resolution", domain=domain)
+        return bool(ips)
 
     async def _get_ips_uncached(self, domain: str) -> tuple[str, ...]:
         ips: list[str] = []

--- a/domain_scout/tests/conftest.py
+++ b/domain_scout/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared test fixtures and factories."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from domain_scout.models import EntityInput, RunMetadata, ScoutResult
+
+
+def mock_result() -> ScoutResult:
+    """Build a minimal ScoutResult for mocking discover_async."""
+    return ScoutResult(
+        entity=EntityInput(company_name="TestCorp", seed_domain=["test.com"]),
+        domains=[],
+        run_metadata=RunMetadata(
+            tool_version="0.3.0",
+            timestamp=datetime.now(UTC),
+            elapsed_seconds=1.0,
+            domains_found=0,
+        ),
+    )

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +13,8 @@ if TYPE_CHECKING:
 from fastapi.testclient import TestClient
 
 from domain_scout.api import ScanRequest, create_app, get_app
-from domain_scout.models import EntityInput, RunMetadata, ScoutResult
+from domain_scout.models import EntityInput
+from domain_scout.tests.conftest import mock_result as _mock_result
 
 
 @pytest.fixture
@@ -22,20 +22,6 @@ def client() -> TestClient:
     """Create a test client with no cache."""
     app = create_app(cache=None, max_concurrent=2)
     return TestClient(app)
-
-
-def _mock_result() -> ScoutResult:
-    """Build a minimal ScoutResult for mocking discover_async."""
-    return ScoutResult(
-        entity=EntityInput(company_name="TestCorp", seed_domain=["test.com"]),
-        domains=[],
-        run_metadata=RunMetadata(
-            tool_version="0.3.0",
-            timestamp=datetime.now(UTC),
-            elapsed_seconds=1.0,
-            domains_found=0,
-        ),
-    )
 
 
 @pytest.fixture

--- a/domain_scout/tests/test_cli.py
+++ b/domain_scout/tests/test_cli.py
@@ -18,10 +18,8 @@ from domain_scout.cli import app
 from domain_scout.models import (
     DeltaReport,
     DeltaSummary,
-    EntityInput,
-    RunMetadata,
-    ScoutResult,
 )
+from domain_scout.tests.conftest import mock_result as _mock_result
 
 
 @pytest.fixture
@@ -34,22 +32,6 @@ def mock_configure_logging() -> Iterator[None]:
     """Prevent CLI from reconfiguring structlog with closed streams."""
     with patch("domain_scout.cli.configure_logging"):
         yield
-
-
-def _mock_result() -> ScoutResult:
-    """Build a minimal ScoutResult for mocking discover."""
-    from datetime import UTC, datetime
-
-    return ScoutResult(
-        entity=EntityInput(company_name="TestCorp", seed_domain=["test.com"]),
-        domains=[],
-        run_metadata=RunMetadata(
-            tool_version="0.3.0",
-            timestamp=datetime.now(UTC),
-            elapsed_seconds=1.0,
-            domains_found=0,
-        ),
-    )
 
 
 class TestScoutCommand:

--- a/domain_scout/tests/test_dns_utils.py
+++ b/domain_scout/tests/test_dns_utils.py
@@ -23,14 +23,14 @@ class TestDNSChecker:
 
     @pytest.mark.asyncio
     async def test_resolves_success(self, checker: DNSChecker) -> None:
-        """resolves() should return True if A or AAAA records exist."""
-        with patch.object(checker._resolver, "resolve", new_callable=AsyncMock):
+        """resolves() should return True if get_ips returns results."""
+        with patch.object(checker, "get_ips", return_value=["1.2.3.4"]):
             assert await checker.resolves("example.com") is True
 
     @pytest.mark.asyncio
     async def test_resolves_failure(self, checker: DNSChecker) -> None:
-        """resolves() should return False if no records found."""
-        with patch.object(checker._resolver, "resolve", side_effect=dns.exception.DNSException):
+        """resolves() should return False if get_ips returns empty."""
+        with patch.object(checker, "get_ips", return_value=[]):
             assert await checker.resolves("example.com") is False
 
     @pytest.mark.asyncio

--- a/domain_scout/tests/test_scout_internals.py
+++ b/domain_scout/tests/test_scout_internals.py
@@ -1,45 +1,8 @@
-"""Unit tests for internal helper functions and error handling in scout.py."""
+"""Unit tests for internal helper functions in scout.py."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
-
-import pytest
-
-from domain_scout._metrics import SOURCE_ERRORS_TOTAL
-from domain_scout.scout import Scout, _extract_sans
-
-
-class TestStrategySeedExpansionErrorHandling:
-    """Test error handling in Scout._strategy_seed_expansion."""
-
-    @pytest.mark.asyncio
-    @patch("domain_scout.scout.inc")
-    async def test_search_by_domain_exception(self, mock_inc: AsyncMock) -> None:
-        """Verify _strategy_seed_expansion handles CT search exceptions gracefully."""
-        scout = Scout()
-        # Mock _ct to raise an Exception on search_by_domain
-        scout._ct = AsyncMock()
-        scout._ct.search_by_domain.side_effect = Exception("Mock timeout or connection error")
-
-        errors: list[str] = []
-
-        results = await scout._strategy_seed_expansion(
-            seed_domain="example.com", company_name="Example Inc", errors=errors
-        )
-
-        # Assert results list is empty
-        assert results == []
-
-        # Assert that the error is appended correctly
-        assert len(errors) == 1
-        assert "CT seed expansion failed: Mock timeout or connection error" in errors[0]
-
-        # Assert that the metric inc() was called
-        mock_inc.assert_called_once()
-        args, kwargs = mock_inc.call_args
-        assert args[0] is SOURCE_ERRORS_TOTAL
-        assert kwargs.get("source") == "ct"
+from domain_scout.scout import _extract_sans
 
 
 def test_extract_sans_missing_key() -> None:


### PR DESCRIPTION
## Summary
- **resolves() → get_ips()**: DNS `resolves()` now delegates to cached `get_ips()`, eliminating duplicate DNS queries (seed validation + bulk_resolve were querying the same domain twice)
- **CT record reuse**: `_validate_seed` passes its CT records to `_strategy_seed_expansion`, eliminating a duplicate crt.sh Postgres query per seed (saves 1-5s per seed)
- **Inner loop optimization**: Uses pre-computed `unique_bases` set instead of recomputing `extract_base_domain` on every SAN in the seed expansion loop
- **Module-level constant**: `_pkg_version()` hoisted to `_TOOL_VERSION` (was called per-scan)
- **Test dedup**: Shared `mock_result()` factory in `conftest.py`, removed duplicate error handling test

## Test plan
- [ ] 492 tests pass locally (lint + mypy + pytest)
- [ ] Verify scan results unchanged: `uv run domain-scout scout --name "Walmart" --seed walmart.com`
- [ ] Verify DNS cache hit rate: seed domains should show 0 redundant queries in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)