### PR TITLE
Fix Claude Code Review permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

- Set `pull-requests: write` and `issues: write` in claude-code-review.yml
- Previous runs had 19-35 permission denials and posted zero comments

Must merge before PR #76 can pass review check (OIDC requires workflow to match main).

## Test plan

- [ ] Merge this, then re-run PR #76 checks to confirm review posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)