### PR TITLE
🧹 [domain_scout] Handle potential division by zero in _fuzzy_best

### DIFF
--- a/domain_scout/matching/entity_match.py
+++ b/domain_scout/matching/entity_match.py
@@ -225,7 +225,7 @@ def _fuzzy_best(a: str, b: str) -> float:
     # Penalize partial/token-set more when strings differ greatly in length.
     # Short substrings ("bank") matching inside long names ("deutsche bank")
     # get inflated scores without this guard.
-    length_ratio = min(len(a), len(b)) / max(len(a), len(b))
+    length_ratio = min(len(a), len(b)) / (max(len(a), len(b)) or 1)
     if length_ratio < 0.4:
         token_set *= 0.70
         partial *= 0.70


### PR DESCRIPTION
This PR addresses a potential `ZeroDivisionError` in the `_fuzzy_best` function within `domain_scout/matching/entity_match.py`.

The issue was identified in the `length_ratio` calculation where `max(len(a), len(b))` was used as a denominator. By changing this to `(max(len(a), len(b)) or 1)`, we ensure that even if both strings are empty, the code will not crash and instead return a `length_ratio` of `0.0`.

While current early guards in the function prevent empty strings from reaching this calculation, this change fulfills a `FIXME` comment and adds a layer of defensive programming to the core matching logic.

All temporary verification scripts used during development have been removed to ensure a clean submission.

---
*PR created automatically by Jules for task [7521044914930826599](https://jules.google.com/task/7521044914930826599) started by @minghsuy*