### PR TITLE
🧪 [add unit tests for scorer and fix TLD case sensitivity]

### DIFF
--- a/domain_scout/scorer/__init__.py
+++ b/domain_scout/scorer/__init__.py
@@ -86,7 +86,7 @@ _COUNTRY_TLDS = frozenset("." + cc for cc in _CC_CODES.split())
 
 
 def _tld_is_country(domain: str) -> int:
-    tld = "." + domain.rsplit(".", maxsplit=1)[-1]
+    tld = "." + domain.rsplit(".", maxsplit=1)[-1].lower()
     return 1 if tld in _COUNTRY_TLDS else 0
 
 

--- a/domain_scout/tests/test_scorer.py
+++ b/domain_scout/tests/test_scorer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from domain_scout.scorer import (
+    _clean_name,
+    _domain_has_company_token,
+    _entity_name_in_org,
+    _tld_is_country,
+)
+
+
+@pytest.mark.parametrize(
+    "domain, expected",
+    [
+        ("example.uk", 1),
+        ("example.de", 1),
+        ("example.jp", 1),
+        ("example.us", 1),
+        ("sub.example.co.uk", 1),
+        ("example.com", 0),
+        ("example.net", 0),
+        ("example.org", 0),
+        ("example.gov", 0),
+        ("example.edu", 0),
+        ("example.io", 1),
+        ("example.ai", 1),
+        ("example.UK", 1),
+        ("EXAMPLE.DE", 1),
+    ],
+)
+def test_tld_is_country_happy_paths(domain: str, expected: int) -> None:
+    assert _tld_is_country(domain) == expected
+
+
+def test_tld_is_country_no_dots() -> None:
+    assert _tld_is_country("uk") == 1
+    assert _tld_is_country("com") == 0
+
+
+def test_tld_is_country_empty_string() -> None:
+    assert _tld_is_country("") == 0
+
+
+def test_tld_is_country_trailing_dot() -> None:
+    assert _tld_is_country("example.uk.") == 0
+
+
+@pytest.mark.parametrize(
+    "domain, company_name, expected",
+    [
+        ("acme-services.com", "Acme Corp", 1),
+        ("something-else.com", "Acme Corp", 0),
+        ("acme.com", "The Acme Company Inc.", 1),
+        ("abc.com", "A B C", 0),
+    ],
+)
+def test_domain_has_company_token(domain: str, company_name: str, expected: int) -> None:
+    assert _domain_has_company_token(domain, company_name) == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("The Acme Company Inc.", "acme"),
+        ("Palo Alto Networks", "palo alto networks"),
+    ],
+)
+def test_clean_name(name: str, expected: str) -> None:
+    assert _clean_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    "company_name, cert_org_names, expected",
+    [
+        ("Acme Corp", {"Acme Services", "Other Corp"}, 1),
+        ("Acme", {"Acme"}, 0),
+        ("abc", {"abc corp"}, 0),
+    ],
+)
+def test_entity_name_in_org(company_name: str, cert_org_names: set[str], expected: int) -> None:
+    assert _entity_name_in_org(company_name, cert_org_names) == expected


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `_tld_is_country` function and other internal helpers in `domain_scout/scorer/__init__.py`. Identified and fixed a case-sensitivity bug where uppercase TLDs were not correctly identified as country TLDs.

📊 **Coverage:**
- `_tld_is_country`: Tested with common ccTLDs, gTLDs, multi-level domains, case sensitivity (e.g., `.UK`), missing dots, empty strings, and trailing dots.
- `_domain_has_company_token`: Tested with various domain and company name combinations.
- `_clean_name`: Verified token cleaning and stop word removal.
- `_entity_name_in_org`: Verified organization name matching logic.

✨ **Result:** Improved the reliability of the confidence scorer by ensuring its core utility functions are well-tested and handle edge cases correctly. The TLD check is now case-insensitive, aligning with DNS standards.

---
*PR created automatically by Jules for task [10265539227902504451](https://jules.google.com/task/10265539227902504451) started by @minghsuy*