### PR TITLE
🧹 [Refactor confidence scoring into a dedicated module]

### DIFF
--- a/domain_scout/matching/scoring.py
+++ b/domain_scout/matching/scoring.py
@@ -1,0 +1,122 @@
+"""Confidence scoring for discovered domains."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from domain_scout.matching.entity_match import org_name_similarity
+
+if TYPE_CHECKING:
+    from domain_scout.config import ScoutConfig
+    from domain_scout.models import DomainAccumulator
+
+
+class ConfidenceScorer:
+    """Orchestrates confidence scoring using heuristic or learned models."""
+
+    def __init__(self, config: ScoutConfig) -> None:
+        self.config = config
+
+    def score(
+        self,
+        accum: DomainAccumulator,
+        company_name: str,
+        seed_domains: list[str],
+        domain: str = "",
+    ) -> float:
+        """Calculate confidence score for a domain discovery."""
+        if self.config.use_learned_scorer and domain and accum.cert_org_names:
+            return self._score_learned(accum, company_name, domain)
+
+        return self._score_heuristic(accum, company_name)
+
+    def _score_learned(
+        self,
+        accum: DomainAccumulator,
+        company_name: str,
+        domain: str,
+    ) -> float:
+        """Score using the learned logistic regression model."""
+        from domain_scout.scorer import score_confidence as _learned_score
+
+        best_sim = max(
+            (org_name_similarity(cert_org, company_name) for cert_org in accum.cert_org_names),
+            default=0.0,
+        )
+
+        # Count unique cert IDs for evidence_density
+        cert_ids: set[int] = set()
+        for ev in accum.evidence:
+            if ev.cert_id is not None:
+                cert_ids.add(ev.cert_id)
+
+        # Extract max RDAP registrant similarity from evidence
+        rdap_sim = max(
+            (
+                ev.similarity_score
+                for ev in accum.evidence
+                if ev.source_type == "rdap_registrant_match" and ev.similarity_score is not None
+            ),
+            default=0.0,
+        )
+
+        return _learned_score(
+            domain=domain,
+            company_name=company_name,
+            best_similarity=best_sim,
+            sources=accum.sources,
+            cert_org_names=accum.cert_org_names,
+            resolves=accum.resolves,
+            evidence_count=len(accum.evidence),
+            unique_cert_count=len(cert_ids),
+            rdap_similarity=rdap_sim,
+        )
+
+    def _score_heuristic(self, accum: DomainAccumulator, company_name: str) -> float:
+        """Score using rule-based heuristics."""
+        # Phase 1: base score from source type
+        score = 0.0
+
+        if "cross_seed_verified" in accum.sources:
+            score = max(score, 0.90)
+        if "ct_org_match" in accum.sources:
+            score = max(score, 0.85)
+        if "ct_subsidiary_match" in accum.sources:
+            score = max(score, 0.80)
+        if any(s.startswith("ct_san_expansion:") for s in accum.sources):
+            score = max(score, 0.80)
+        if any(s.startswith("ct_seed_subdomain:") for s in accum.sources):
+            score = max(score, 0.75)
+        if any(s.startswith("ct_seed_related:") for s in accum.sources):
+            score = max(score, 0.40)
+        if "dns_guess" in accum.sources and "ct_org_match" not in accum.sources:
+            score = max(score, 0.30)
+
+        # Phase 2: corroboration level adjustment
+        # dns_guess bypasses corroboration — it already implies resolution
+        if score <= 0.30:
+            return round(score, 2)
+
+        has_resolves = accum.resolves
+        has_rdap = "rdap_registrant_match" in accum.sources
+
+        best_sim = max(
+            (org_name_similarity(cert_org, company_name) for cert_org in accum.cert_org_names),
+            default=0.0,
+        )
+        has_high_sim = best_sim > 0.9
+
+        has_multi_source = len(accum.sources) >= 3
+
+        if has_resolves and (has_rdap or has_high_sim) and has_multi_source:
+            adjustment = 0.10  # Level 3: strong corroboration
+        elif has_resolves and (has_rdap or has_high_sim or has_multi_source):
+            adjustment = 0.05  # Level 2: moderate corroboration
+        elif has_resolves:
+            adjustment = 0.00  # Level 1: resolves only
+        else:
+            adjustment = -0.05  # Level 0: no resolution
+
+        score = min(1.0, max(0.0, score + adjustment))
+
+        return round(score, 2)

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 — Pydantic needs runtime import
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class EntityInput(BaseModel):
@@ -116,3 +120,80 @@ class DeltaReport(BaseModel):
     warnings: list[DeltaWarning] = Field(default_factory=list)
     baseline_metadata: RunMetadata
     current_metadata: RunMetadata
+
+
+# --- Internal processing helpers and classes ---
+
+
+def _normalize_time(val: object) -> str | None:
+    """Normalize a datetime or string to ISO string for consistent comparison.
+
+    CT Postgres returns datetime objects, JSON API and cache return strings.
+    Normalizing to ISO strings prevents TypeError on mixed-type comparison.
+    """
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val.isoformat()
+    if isinstance(val, str):
+        if not val:
+            return None
+        try:
+            return datetime.fromisoformat(val).isoformat()
+        except ValueError:
+            return val
+    return str(val)
+
+
+def _parse_time(val: str | None) -> datetime | None:
+    """Parse an ISO 8601 string back to datetime for Pydantic output."""
+    if val is None:
+        return None
+    return datetime.fromisoformat(val)
+
+
+class DomainAccumulator:
+    """Mutable accumulator for evidence about a single domain."""
+
+    __slots__ = (
+        "sources",
+        "evidence",
+        "cert_org_names",
+        "first_seen",
+        "last_seen",
+        "resolves",
+        "rdap_org",
+        "confidence",
+    )
+
+    def __init__(self) -> None:
+        self.sources: set[str] = set()
+        self.evidence: list[EvidenceRecord] = []
+        self.cert_org_names: set[str] = set()
+        self.first_seen: str | None = None
+        self.last_seen: str | None = None
+        self.resolves: bool = False
+        self.rdap_org: str | None = None
+        self.confidence: float = 0.0
+
+    def merge(self, other: DomainAccumulator) -> None:
+        self.sources |= other.sources
+        self.evidence.extend(other.evidence)
+        self.cert_org_names |= other.cert_org_names
+        o_first = _normalize_time(other.first_seen)
+        if o_first and (self.first_seen is None or o_first < self.first_seen):
+            self.first_seen = o_first
+        o_last = _normalize_time(other.last_seen)
+        if o_last and (self.last_seen is None or o_last > self.last_seen):
+            self.last_seen = o_last
+        self.resolves = self.resolves or other.resolves
+        if self.rdap_org is None and other.rdap_org is not None:
+            self.rdap_org = other.rdap_org
+
+    def update_times(self, not_before: object, not_after: object) -> None:
+        nb = _normalize_time(not_before)
+        na = _normalize_time(not_after)
+        if nb and (self.first_seen is None or nb < self.first_seen):
+            self.first_seen = nb
+        if na and (self.last_seen is None or na > self.last_seen):
+            self.last_seen = na

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -31,12 +31,16 @@ from domain_scout.matching.entity_match import (
     normalize_org_name,
     org_name_similarity,
 )
+from domain_scout.matching.scoring import ConfidenceScorer
 from domain_scout.models import (
     DiscoveredDomain,
+    DomainAccumulator,
     EntityInput,
     EvidenceRecord,
     RunMetadata,
     ScoutResult,
+    _normalize_time,
+    _parse_time,
 )
 from domain_scout.sources.ct_logs import CTLogSource, extract_base_domain, is_valid_domain
 from domain_scout.sources.dns_utils import DNSChecker
@@ -221,6 +225,7 @@ class Scout:
         else:
             self._rdap = rdap_inner
         self._dns = DNSChecker(self.config)
+        self._scorer = ConfidenceScorer(self.config)
         self._subsidiaries: dict[str, list[str]] = {}
         if self.config.subsidiaries_path:
             try:
@@ -285,7 +290,7 @@ class Scout:
         seeds = entity.seed_domain  # list[str]
 
         # Accumulator: domain -> evidence dict
-        domain_evidence: dict[str, _DomainAccum] = {}
+        domain_evidence: dict[str, DomainAccumulator] = {}
 
         def _remaining() -> float:
             return max(0.0, total_budget - (time.monotonic() - t0))
@@ -308,7 +313,7 @@ class Scout:
         seed_cross_verification: dict[str, list[str]] = {}
         seed_ct_records: dict[str, list[dict[str, Any]]] = {}
 
-        independent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
+        independent_tasks: list[asyncio.Task[list[tuple[str, DomainAccumulator]]]] = []
 
         # Strategy A: org name search (independent of seed)
         independent_tasks.append(
@@ -399,7 +404,7 @@ class Scout:
                                 seed_ct_records.setdefault(sd, r["ct_records"])
 
         # Phase 2: Seed-dependent strategies (B + optional second org search)
-        dependent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
+        dependent_tasks: list[asyncio.Task[list[tuple[str, DomainAccumulator]]]] = []
 
         # Extra org searches from seed-derived org names
         seen_org_searches: set[str] = set()
@@ -661,8 +666,8 @@ class Scout:
         rec: dict[str, Any],
         org_name: str,
         source_tag: str,
-    ) -> list[tuple[str, _DomainAccum]]:
-        results: list[tuple[str, _DomainAccum]] = []
+    ) -> list[tuple[str, DomainAccumulator]]:
+        results: list[tuple[str, DomainAccumulator]] = []
         cert_org = rec.get("org_name")
         if not isinstance(cert_org, str) or not cert_org:
             return results
@@ -682,7 +687,7 @@ class Scout:
             base = extract_base_domain(name)
             if not base:
                 continue
-            accum = _DomainAccum()
+            accum = DomainAccumulator()
             accum.sources.add(source_tag)
             desc = f"Cert org '{cert_org}' matches target (score={similarity:.2f})"
             accum.evidence.append(
@@ -708,8 +713,8 @@ class Scout:
         org_name: str,
         errors: list[str],
         source_tag: str = "ct_org_match",
-    ) -> list[tuple[str, _DomainAccum]]:
-        results: list[tuple[str, _DomainAccum]] = []
+    ) -> list[tuple[str, DomainAccumulator]]:
+        results: list[tuple[str, DomainAccumulator]] = []
         try:
             records = await self._ct.search_by_org(org_name)
         except Exception as exc:
@@ -730,8 +735,8 @@ class Scout:
         company_name: str,
         errors: list[str],
         ct_records: list[dict[str, Any]] | None = None,
-    ) -> list[tuple[str, _DomainAccum]]:
-        results: list[tuple[str, _DomainAccum]] = []
+    ) -> list[tuple[str, DomainAccumulator]]:
+        results: list[tuple[str, DomainAccumulator]] = []
         if ct_records is not None:
             records = ct_records
         else:
@@ -766,7 +771,7 @@ class Scout:
                 if not base:
                     continue
 
-                accum = _DomainAccum()
+                accum = DomainAccumulator()
 
                 # Is this a SAN on a cert that also covers the seed domain?
                 has_seed_san = seed_base in unique_bases
@@ -830,7 +835,7 @@ class Scout:
 
     async def _strategy_domain_guess(
         self, company_name: str, location: str | None, errors: list[str]
-    ) -> list[tuple[str, _DomainAccum]]:
+    ) -> list[tuple[str, DomainAccumulator]]:
         slugs = domain_from_company_name(company_name)
         # Also try with location keywords
         if location:
@@ -848,14 +853,14 @@ class Scout:
         resolve_map = await self._dns.bulk_resolve(candidates)
 
         # Return resolving candidates at low confidence (Strategy A handles CT matching)
-        results: list[tuple[str, _DomainAccum]] = []
+        results: list[tuple[str, DomainAccumulator]] = []
         for domain, does_resolve in resolve_map.items():
             if not does_resolve:
                 continue
             base = extract_base_domain(domain)
             if not base:
                 continue
-            accum = _DomainAccum()
+            accum = DomainAccumulator()
             accum.sources.add("dns_guess")
             accum.evidence.append(
                 EvidenceRecord(
@@ -871,7 +876,7 @@ class Scout:
     # --- Cross-seed detection ---
 
     @staticmethod
-    def _apply_cross_seed_boost(domain_evidence: dict[str, _DomainAccum], seeds: list[str]) -> None:
+    def _apply_cross_seed_boost(domain_evidence: dict[str, DomainAccumulator], seeds: list[str]) -> None:
         """Add cross_seed_verified source to domains found from 2+ independent seeds.
 
         Requires at least one strong source (ct_san_expansion or ct_seed_subdomain).
@@ -897,96 +902,14 @@ class Scout:
 
     def _score_confidence(
         self,
-        accum: _DomainAccum,
+        accum: DomainAccumulator,
         company_name: str,
         seed_domains: list[str],
         domain: str = "",
     ) -> float:
-        # Learned scorer path (opt-in via config)
-        if self.config.use_learned_scorer and domain and accum.cert_org_names:
-            from domain_scout.scorer import score_confidence as _learned_score
+        return self._scorer.score(accum, company_name, seed_domains, domain)
 
-            best_sim = max(
-                (org_name_similarity(cert_org, company_name) for cert_org in accum.cert_org_names),
-                default=0.0,
-            )
-            # Count unique cert IDs for evidence_density
-            cert_ids: set[int] = set()
-            for ev in accum.evidence:
-                if ev.cert_id is not None:
-                    cert_ids.add(ev.cert_id)
-
-            # Extract max RDAP registrant similarity from evidence
-            rdap_sim = max(
-                (
-                    ev.similarity_score
-                    for ev in accum.evidence
-                    if ev.source_type == "rdap_registrant_match" and ev.similarity_score is not None
-                ),
-                default=0.0,
-            )
-
-            return _learned_score(
-                domain=domain,
-                company_name=company_name,
-                best_similarity=best_sim,
-                sources=accum.sources,
-                cert_org_names=accum.cert_org_names,
-                resolves=accum.resolves,
-                evidence_count=len(accum.evidence),
-                unique_cert_count=len(cert_ids),
-                rdap_similarity=rdap_sim,
-            )
-
-        # Heuristic scorer (default)
-        # Phase 1: base score from source type
-        score = 0.0
-
-        if "cross_seed_verified" in accum.sources:
-            score = max(score, 0.90)
-        if "ct_org_match" in accum.sources:
-            score = max(score, 0.85)
-        if "ct_subsidiary_match" in accum.sources:
-            score = max(score, 0.80)
-        if any(s.startswith("ct_san_expansion:") for s in accum.sources):
-            score = max(score, 0.80)
-        if any(s.startswith("ct_seed_subdomain:") for s in accum.sources):
-            score = max(score, 0.75)
-        if any(s.startswith("ct_seed_related:") for s in accum.sources):
-            score = max(score, 0.40)
-        if "dns_guess" in accum.sources and "ct_org_match" not in accum.sources:
-            score = max(score, 0.30)
-
-        # Phase 2: corroboration level adjustment
-        # dns_guess bypasses corroboration — it already implies resolution
-        if score <= 0.30:
-            return round(score, 2)
-
-        has_resolves = accum.resolves
-        has_rdap = "rdap_registrant_match" in accum.sources
-
-        best_sim = max(
-            (org_name_similarity(cert_org, company_name) for cert_org in accum.cert_org_names),
-            default=0.0,
-        )
-        has_high_sim = best_sim > 0.9
-
-        has_multi_source = len(accum.sources) >= 3
-
-        if has_resolves and (has_rdap or has_high_sim) and has_multi_source:
-            adjustment = 0.10  # Level 3: strong corroboration
-        elif has_resolves and (has_rdap or has_high_sim or has_multi_source):
-            adjustment = 0.05  # Level 2: moderate corroboration
-        elif has_resolves:
-            adjustment = 0.00  # Level 1: resolves only
-        else:
-            adjustment = -0.05  # Level 0: no resolution
-
-        score = min(1.0, max(0.0, score + adjustment))
-
-        return round(score, 2)
-
-    async def _infra_boost(self, reference: str, evidence: dict[str, _DomainAccum]) -> None:
+    async def _infra_boost(self, reference: str, evidence: dict[str, DomainAccumulator]) -> None:
         """Small confidence boost for domains sharing infra with a reference domain."""
         # Select top candidates by confidence, capped
         candidates = [
@@ -997,7 +920,7 @@ class Scout:
         candidates.sort(key=lambda x: x[1].confidence, reverse=True)
         candidates = candidates[: self.config.infra_check_max]
 
-        async def _check(domain: str, accum: _DomainAccum) -> None:
+        async def _check(domain: str, accum: DomainAccumulator) -> None:
             try:
                 shared = await self._dns.shares_infrastructure(reference, domain)
                 if not shared:
@@ -1028,7 +951,7 @@ class Scout:
     # --- RDAP corroboration ---
 
     async def _rdap_corroborate(
-        self, domain_evidence: dict[str, _DomainAccum], company_name: str
+        self, domain_evidence: dict[str, DomainAccumulator], company_name: str
     ) -> None:
         """Query RDAP on top resolving candidates and add corroborating evidence."""
         # Select resolving candidates without existing rdap_registrant_match
@@ -1044,7 +967,7 @@ class Scout:
         if not candidates:
             return
 
-        async def _check(domain: str, accum: _DomainAccum) -> None:
+        async def _check(domain: str, accum: DomainAccumulator) -> None:
             try:
                 rdap_org = await self._rdap.get_registrant_org(domain)
                 if not rdap_org:
@@ -1079,7 +1002,7 @@ class Scout:
     # --- Step 4: Build output ---
 
     def _build_output(
-        self, evidence: dict[str, _DomainAccum], seed_domains: list[str]
+        self, evidence: dict[str, DomainAccumulator], seed_domains: list[str]
     ) -> list[DiscoveredDomain]:
         domains: list[DiscoveredDomain] = []
         seed_bases = {extract_base_domain(sd) for sd in seed_domains} - {None}
@@ -1160,77 +1083,3 @@ def _extract_sans(rec: dict[str, object]) -> list[str]:
     raw = rec.get("san_dns_names")
     sans: list[str] = raw if isinstance(raw, list) else []
     return sans
-
-
-def _normalize_time(val: object) -> str | None:
-    """Normalize a datetime or string to ISO string for consistent comparison.
-
-    CT Postgres returns datetime objects, JSON API and cache return strings.
-    Normalizing to ISO strings prevents TypeError on mixed-type comparison.
-    """
-    if val is None:
-        return None
-    if isinstance(val, datetime):
-        return val.isoformat()
-    if isinstance(val, str):
-        if not val:
-            return None
-        try:
-            return datetime.fromisoformat(val).isoformat()
-        except ValueError:
-            return val
-    return str(val)
-
-
-def _parse_time(val: str | None) -> datetime | None:
-    """Parse an ISO 8601 string back to datetime for Pydantic output."""
-    if val is None:
-        return None
-    return datetime.fromisoformat(val)
-
-
-class _DomainAccum:
-    """Mutable accumulator for evidence about a single domain."""
-
-    __slots__ = (
-        "sources",
-        "evidence",
-        "cert_org_names",
-        "first_seen",
-        "last_seen",
-        "resolves",
-        "rdap_org",
-        "confidence",
-    )
-
-    def __init__(self) -> None:
-        self.sources: set[str] = set()
-        self.evidence: list[EvidenceRecord] = []
-        self.cert_org_names: set[str] = set()
-        self.first_seen: str | None = None
-        self.last_seen: str | None = None
-        self.resolves: bool = False
-        self.rdap_org: str | None = None
-        self.confidence: float = 0.0
-
-    def merge(self, other: _DomainAccum) -> None:
-        self.sources |= other.sources
-        self.evidence.extend(other.evidence)
-        self.cert_org_names |= other.cert_org_names
-        o_first = _normalize_time(other.first_seen)
-        if o_first and (self.first_seen is None or o_first < self.first_seen):
-            self.first_seen = o_first
-        o_last = _normalize_time(other.last_seen)
-        if o_last and (self.last_seen is None or o_last > self.last_seen):
-            self.last_seen = o_last
-        self.resolves = self.resolves or other.resolves
-        if self.rdap_org is None and other.rdap_org is not None:
-            self.rdap_org = other.rdap_org
-
-    def update_times(self, not_before: object, not_after: object) -> None:
-        nb = _normalize_time(not_before)
-        na = _normalize_time(not_after)
-        if nb and (self.first_seen is None or nb < self.first_seen):
-            self.first_seen = nb
-        if na and (self.last_seen is None or na > self.last_seen):
-            self.last_seen = na

--- a/domain_scout/tests/test_multi_seed.py
+++ b/domain_scout/tests/test_multi_seed.py
@@ -10,12 +10,13 @@ import pytest
 from domain_scout.config import ScoutConfig
 from domain_scout.models import (
     DiscoveredDomain,
+    DomainAccumulator,
     EntityInput,
     EvidenceRecord,
     RunMetadata,
     ScoutResult,
 )
-from domain_scout.scout import Scout, _DomainAccum, _extract_contributing_seeds
+from domain_scout.scout import Scout, _extract_contributing_seeds
 
 # Shared stub result for backward compat tests
 _STUB_META = RunMetadata(
@@ -33,8 +34,8 @@ class TestApplyCrossSeedBoost:
     """Test the static _apply_cross_seed_boost method."""
 
     def test_no_boost_single_seed(self) -> None:
-        evidence: dict[str, _DomainAccum] = {}
-        a = _DomainAccum()
+        evidence: dict[str, DomainAccumulator] = {}
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         evidence["samsclub.com"] = a
 
@@ -42,7 +43,7 @@ class TestApplyCrossSeedBoost:
         assert "cross_seed_verified" not in a.sources
 
     def test_boost_two_seeds(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_san_expansion:samsclub.com")
         evidence = {"walmartlabs.com": a}
@@ -52,7 +53,7 @@ class TestApplyCrossSeedBoost:
         assert any(e.source_type == "cross_seed_verified" for e in a.evidence)
 
     def test_boost_mixed_source_types(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_seed_related:samsclub.com")
         evidence = {"example.com": a}
@@ -62,7 +63,7 @@ class TestApplyCrossSeedBoost:
 
     def test_no_boost_same_seed_different_types(self) -> None:
         """Two source types from the same seed should NOT trigger cross-verification."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_seed_subdomain:walmart.com")
         evidence = {"example.com": a}
@@ -71,7 +72,7 @@ class TestApplyCrossSeedBoost:
         assert "cross_seed_verified" not in a.sources
 
     def test_boost_three_seeds(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:a.com")
         a.sources.add("ct_san_expansion:b.com")
         a.sources.add("ct_seed_related:c.com")
@@ -81,7 +82,7 @@ class TestApplyCrossSeedBoost:
         assert "cross_seed_verified" in a.sources
 
     def test_domains_without_seed_sources_unaffected(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.sources.add("dns_guess")
         evidence = {"example.com": a}
@@ -98,7 +99,7 @@ class TestScoreConfidenceMultiSeed:
         self.scout = Scout(config=ScoutConfig())
 
     def test_cross_seed_verified_score(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("cross_seed_verified")
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_san_expansion:samsclub.com")
@@ -109,31 +110,31 @@ class TestScoreConfidenceMultiSeed:
 
     def test_tagged_san_expansion_no_resolves(self) -> None:
         """ct_san_expansion:seed without resolution gets -0.05 penalty."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         score = self.scout._score_confidence(a, "Walmart", ["walmart.com"])
         assert score == 0.75
 
     def test_tagged_seed_subdomain_no_resolves(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_subdomain:walmart.com")
         score = self.scout._score_confidence(a, "Walmart", ["walmart.com"])
         assert score == 0.70
 
     def test_tagged_seed_related_no_resolves(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_related:walmart.com")
         score = self.scout._score_confidence(a, "Walmart", ["walmart.com"])
         assert score == 0.35
 
     def test_no_seeds_no_resolves(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         score = self.scout._score_confidence(a, "Walmart", [])
         assert score == 0.80
 
     def test_cross_seed_with_org_match_takes_highest(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("cross_seed_verified")
         a.sources.add("ct_org_match")
         a.sources.add("ct_san_expansion:walmart.com")
@@ -153,7 +154,7 @@ class TestBuildOutputSeedSources:
         self.scout = Scout(config=ScoutConfig())
 
     def test_seed_sources_populated(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_san_expansion:samsclub.com")
         a.sources.add("cross_seed_verified")
@@ -166,7 +167,7 @@ class TestBuildOutputSeedSources:
         assert sorted(domains[0].seed_sources) == ["samsclub.com", "walmart.com"]
 
     def test_is_seed_multi(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_subdomain:walmart.com")
         a.confidence = 0.90
         a.resolves = True
@@ -177,7 +178,7 @@ class TestBuildOutputSeedSources:
         assert domains[0].is_seed is True
 
     def test_empty_seed_sources_when_no_seeds(self) -> None:
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.confidence = 0.90
         a.resolves = True
@@ -267,10 +268,10 @@ class TestSimulatedScenarios:
 
     def test_walmart_samsclub_cross_verification(self) -> None:
         """Simulate: walmart.com and samsclub.com both find walmartlabs.com."""
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
 
         # walmartlabs.com found via walmart.com seed expansion
-        a1 = _DomainAccum()
+        a1 = DomainAccumulator()
         a1.sources.add("ct_san_expansion:walmart.com")
         a1.evidence.append(
             EvidenceRecord(
@@ -283,7 +284,7 @@ class TestSimulatedScenarios:
         evidence["walmartlabs.com"] = a1
 
         # walmartlabs.com also found via samsclub.com seed expansion
-        a2 = _DomainAccum()
+        a2 = DomainAccumulator()
         a2.sources.add("ct_san_expansion:samsclub.com")
         a2.evidence.append(
             EvidenceRecord(
@@ -306,9 +307,9 @@ class TestSimulatedScenarios:
 
     def test_generali_overlap(self) -> None:
         """Simulate: generali.it and generali.com both find generali.de."""
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
 
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:generali.it")
         a.sources.add("ct_san_expansion:generali.com")
         a.sources.add("ct_org_match")
@@ -331,9 +332,9 @@ class TestSimulatedScenarios:
         If Walmart sells ASDA, asda.com might only appear from walmart.com's
         historical certs, not from samsclub.com. No cross-verification boost.
         """
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
 
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.resolves = True
         evidence["asda.com"] = a
@@ -349,11 +350,11 @@ class TestSimulatedScenarios:
 
     def test_cdn_false_positive_not_cross_verified(self) -> None:
         """CDN domain from ct_seed_related only (no strong sources) is not cross-verified."""
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
 
         # cloudflare.com found as ct_seed_related from both seeds (just appeared
         # in search results, not actually on same cert)
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_related:walmart.com")
         a.sources.add("ct_seed_related:samsclub.com")
         a.resolves = True
@@ -368,9 +369,9 @@ class TestSimulatedScenarios:
 
     def test_unrelated_domains_not_boosted(self) -> None:
         """Domains only found via org match (no seed tags) get no cross-seed boost."""
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
 
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.sources.add("dns_guess")
         a.resolves = True
@@ -391,7 +392,7 @@ class TestPostMergerAcquisition:
 
     def test_acquired_brand_pre_integration_one_seed(self) -> None:
         """Domain only on one seed's certs (pre-integration) gets no cross-verify."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.resolves = True
         evidence = {"bonobos.com": a}
@@ -402,7 +403,7 @@ class TestPostMergerAcquisition:
 
     def test_divested_entity_historical_certs(self) -> None:
         """Divested subsidiary with mismatched org gets no cross-verify or org boost."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.cert_org_names.add("ASDA Group")
         a.resolves = True
@@ -414,7 +415,7 @@ class TestPostMergerAcquisition:
 
     def test_acquired_brand_different_source_types(self) -> None:
         """Cross-verification fires across different source types (SAN + subdomain)."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:companya.com")
         a.sources.add("ct_seed_subdomain:companyb.com")
         a.resolves = True
@@ -436,7 +437,7 @@ class TestPostSpinOff:
 
     def test_spinoff_shared_legacy_domain(self) -> None:
         """Shared domain on certs from both post-split seeds gets cross-verified."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:hp.com")
         a.sources.add("ct_san_expansion:hpe.com")
         a.resolves = True
@@ -448,7 +449,7 @@ class TestPostSpinOff:
 
     def test_spinoff_child_domain_not_on_parent_certs(self) -> None:
         """Domain only from one post-split seed gets no cross-verify."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:paypal.com")
         a.resolves = False
         evidence = {"paypal-engineering.com": a}
@@ -459,7 +460,7 @@ class TestPostSpinOff:
 
     def test_spinoff_transition_cert_non_resolving(self) -> None:
         """Cross-verified but non-resolving non-seed domain is excluded from output."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:hp.com")
         a.sources.add("ct_san_expansion:hpe.com")
         a.resolves = False
@@ -474,7 +475,7 @@ class TestPostSpinOff:
 
     def test_spinoff_single_seed_with_resolves(self) -> None:
         """Single-seed domain with resolves gets standard score, no cross-verify."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:hpe.com")
         a.resolves = True
         evidence = {"hpe-services.com": a}
@@ -495,11 +496,11 @@ class TestLookAlikeDifferentEntities:
 
     def test_independent_domains_no_cross(self) -> None:
         """Each seed finds only its own domains -- no cross-verification."""
-        a1 = _DomainAccum()
+        a1 = DomainAccumulator()
         a1.sources.add("ct_san_expansion:delta.com")
         a1.resolves = True
 
-        a2 = _DomainAccum()
+        a2 = DomainAccumulator()
         a2.sources.add("ct_san_expansion:deltafaucet.com")
         a2.resolves = True
 
@@ -514,7 +515,7 @@ class TestLookAlikeDifferentEntities:
 
         Without strong sources, weak evidence from multiple seeds stays at low score.
         """
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_related:delta.com")
         a.sources.add("ct_seed_related:deltafaucet.com")
         a.resolves = True
@@ -530,11 +531,11 @@ class TestLookAlikeDifferentEntities:
 
     def test_completely_isolated_seeds(self) -> None:
         """Zero cert overlap between unrelated seeds -- no cross-verification."""
-        a1 = _DomainAccum()
+        a1 = DomainAccumulator()
         a1.sources.add("ct_san_expansion:apple.com")
         a1.resolves = True
 
-        a2 = _DomainAccum()
+        a2 = DomainAccumulator()
         a2.sources.add("ct_san_expansion:applehospitality.com")
         a2.resolves = False
 
@@ -560,13 +561,13 @@ class TestCrossVerificationEdgeCases:
 
     def test_empty_evidence_dict(self) -> None:
         """Empty evidence dict does not error."""
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
         Scout._apply_cross_seed_boost(evidence, ["a.com", "b.com"])
         assert evidence == {}
 
     def test_single_domain_five_seeds(self) -> None:
         """Domain found by all 5 seeds gets cross-verified to 1.0."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         seeds = ["a.com", "b.com", "c.com", "d.com", "e.com"]
         for seed in seeds:
             a.sources.add(f"ct_san_expansion:{seed}")
@@ -579,7 +580,7 @@ class TestCrossVerificationEdgeCases:
 
     def test_duplicate_seed_no_cross_verify(self) -> None:
         """Same seed listed twice contributes only 1 unique seed -- no cross-verify."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:walmart.com")
         a.sources.add("ct_seed_subdomain:walmart.com")
         evidence = {"example.com": a}
@@ -589,7 +590,7 @@ class TestCrossVerificationEdgeCases:
 
     def test_boost_idempotency(self) -> None:
         """Second boost call is idempotent for sources but appends to evidence list."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_san_expansion:a.com")
         a.sources.add("ct_san_expansion:b.com")
         evidence = {"shared.com": a}
@@ -603,7 +604,7 @@ class TestCrossVerificationEdgeCases:
 
     def test_all_boosts_cap_at_one(self) -> None:
         """Every possible boost stacked still caps at exactly 1.0."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update(
             {
                 "cross_seed_verified",
@@ -619,7 +620,7 @@ class TestCrossVerificationEdgeCases:
 
     def test_seed_domain_own_tag_only_is_seed_not_cross_verified(self) -> None:
         """Seed domain with only its own tag: no cross-verify, but is_seed in output."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_subdomain:walmart.com")
         a.resolves = True
         evidence = {"walmart.com": a}
@@ -635,7 +636,7 @@ class TestCrossVerificationEdgeCases:
 
     def test_seed_domain_cross_verified_from_other_seed(self) -> None:
         """Seed domain with tags from both seeds gets cross-verified."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_seed_subdomain:walmart.com")
         a.sources.add("ct_san_expansion:samsclub.com")
         a.resolves = True
@@ -669,7 +670,7 @@ class TestBuildOutputEdgeCases:
 
     def test_non_resolving_cross_verified_excluded(self) -> None:
         """Non-resolving non-seed domain excluded even with high confidence."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update(
             {
                 "ct_san_expansion:a.com",
@@ -686,7 +687,7 @@ class TestBuildOutputEdgeCases:
 
     def test_below_inclusion_threshold_excluded(self) -> None:
         """Domain below 0.60 inclusion threshold excluded even if it resolves."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("dns_guess")
         a.resolves = True
         a.confidence = 0.35
@@ -697,17 +698,17 @@ class TestBuildOutputEdgeCases:
 
     def test_output_sorts_descending_by_confidence(self) -> None:
         """Output is sorted high-to-low by confidence."""
-        low = _DomainAccum()
+        low = DomainAccumulator()
         low.sources.add("ct_org_match")
         low.resolves = True
         low.confidence = 0.70
 
-        high = _DomainAccum()
+        high = DomainAccumulator()
         high.sources.add("cross_seed_verified")
         high.resolves = True
         high.confidence = 1.0
 
-        mid = _DomainAccum()
+        mid = DomainAccumulator()
         mid.sources.add("ct_san_expansion:a.com")
         mid.resolves = True
         mid.confidence = 0.85
@@ -729,7 +730,7 @@ class TestCorroborationLevels:
 
     def test_level3_resolves_rdap_high_sim(self) -> None:
         """Level 3: resolves + rdap_match + high_sim → +0.10."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update({"ct_org_match", "rdap_registrant_match", "ct_san_expansion:a.com"})
         a.cert_org_names.add("Walmart Inc.")
         a.resolves = True
@@ -738,7 +739,7 @@ class TestCorroborationLevels:
 
     def test_level3_resolves_rdap_multi_source(self) -> None:
         """Level 3: resolves + rdap_match + multi_source → +0.10."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update({"ct_org_match", "rdap_registrant_match", "ct_san_expansion:a.com"})
         a.resolves = True
         score = self.scout._score_confidence(a, "Walmart", ["a.com"])
@@ -746,7 +747,7 @@ class TestCorroborationLevels:
 
     def test_level2_resolves_rdap(self) -> None:
         """Level 2: resolves + rdap_match (no multi_source) → +0.05."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update({"ct_org_match", "rdap_registrant_match"})
         a.resolves = True
         score = self.scout._score_confidence(a, "Walmart", [])
@@ -754,7 +755,7 @@ class TestCorroborationLevels:
 
     def test_level2_resolves_high_sim(self) -> None:
         """Level 2: resolves + high_sim (no rdap) → +0.05."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.cert_org_names.add("Walmart Inc.")
         a.resolves = True
@@ -763,7 +764,7 @@ class TestCorroborationLevels:
 
     def test_level2_resolves_multi_source(self) -> None:
         """Level 2: resolves + multi_source (no rdap, no high_sim) → +0.05."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update({"ct_org_match", "ct_san_expansion:a.com", "ct_seed_subdomain:a.com"})
         a.resolves = True
         score = self.scout._score_confidence(a, "Walmart", ["a.com"])
@@ -771,7 +772,7 @@ class TestCorroborationLevels:
 
     def test_level1_resolves_only(self) -> None:
         """Level 1: resolves only → +0.00."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = True
         score = self.scout._score_confidence(a, "Walmart", [])
@@ -779,7 +780,7 @@ class TestCorroborationLevels:
 
     def test_level0_no_resolves(self) -> None:
         """Level 0: no resolution → -0.05."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = False
         score = self.scout._score_confidence(a, "Walmart", [])
@@ -787,7 +788,7 @@ class TestCorroborationLevels:
 
     def test_cross_seed_rdap_resolves_reaches_one(self) -> None:
         """Cross-seed + rdap + resolves → 1.0."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.update(
             {
                 "cross_seed_verified",
@@ -803,7 +804,7 @@ class TestCorroborationLevels:
 
     def test_dns_guess_stays_at_030(self) -> None:
         """dns_guess stays at 0.30 regardless of corroboration."""
-        a = _DomainAccum()
+        a = DomainAccumulator()
         a.sources.add("dns_guess")
         a.resolves = True
         score = self.scout._score_confidence(a, "Walmart", [])
@@ -823,8 +824,8 @@ class TestRDAPCorroboration:
     @pytest.mark.asyncio
     async def test_adds_rdap_source_on_match(self) -> None:
         """RDAP corroboration adds rdap_registrant_match when org matches."""
-        evidence: dict[str, _DomainAccum] = {}
-        a = _DomainAccum()
+        evidence: dict[str, DomainAccumulator] = {}
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = True
         evidence["walmart.com"] = a
@@ -837,8 +838,8 @@ class TestRDAPCorroboration:
     @pytest.mark.asyncio
     async def test_skips_non_resolving(self) -> None:
         """Non-resolving domains are skipped."""
-        evidence: dict[str, _DomainAccum] = {}
-        a = _DomainAccum()
+        evidence: dict[str, DomainAccumulator] = {}
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = False
         evidence["dead.com"] = a
@@ -850,8 +851,8 @@ class TestRDAPCorroboration:
     async def test_below_threshold_no_source(self) -> None:
         """RDAP org below org_match_threshold doesn't add source."""
         self.scout._rdap.get_registrant_org = AsyncMock(return_value="Totally Different Corp")  # type: ignore[method-assign]
-        evidence: dict[str, _DomainAccum] = {}
-        a = _DomainAccum()
+        evidence: dict[str, DomainAccumulator] = {}
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = True
         evidence["unrelated.com"] = a
@@ -865,8 +866,8 @@ class TestRDAPCorroboration:
         self.scout._rdap.get_registrant_org = AsyncMock(  # type: ignore[method-assign]
             side_effect=Exception("RDAP service down")
         )
-        evidence: dict[str, _DomainAccum] = {}
-        a = _DomainAccum()
+        evidence: dict[str, DomainAccumulator] = {}
+        a = DomainAccumulator()
         a.sources.add("ct_org_match")
         a.resolves = True
         evidence["walmart.com"] = a
@@ -883,9 +884,9 @@ class TestRDAPCorroboration:
         self.scout = Scout(config=config)
         self.scout._rdap.get_registrant_org = AsyncMock(return_value="Walmart Inc.")  # type: ignore[method-assign]
 
-        evidence: dict[str, _DomainAccum] = {}
+        evidence: dict[str, DomainAccumulator] = {}
         for i in range(10):
-            a = _DomainAccum()
+            a = DomainAccumulator()
             a.sources.add("ct_org_match")
             a.resolves = True
             evidence[f"domain{i}.com"] = a

--- a/domain_scout/tests/test_subsidiary.py
+++ b/domain_scout/tests/test_subsidiary.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 import pytest
 
 from domain_scout.config import ScoutConfig
+from domain_scout.models import DomainAccumulator
 from domain_scout.scout import (
     Scout,
     _brand_sort_key,
-    _DomainAccum,
     _filter_subsidiaries,
     load_subsidiary_map,
 )
@@ -240,7 +240,7 @@ class TestSubsidiaryExpansion:
     def test_source_tag_in_scoring(self) -> None:
         """ct_subsidiary_match gets scored at 0.80 base."""
         s = self._make_scout()
-        accum = _DomainAccum()
+        accum = DomainAccumulator()
         accum.sources.add("ct_subsidiary_match")
         # No resolution -> Level 0 -> -0.05
         score = s._score_confidence(accum, "Test Co", [])
@@ -249,7 +249,7 @@ class TestSubsidiaryExpansion:
     def test_source_tag_with_resolution(self) -> None:
         """ct_subsidiary_match with resolution gets Level 1 -> 0.80."""
         s = self._make_scout()
-        accum = _DomainAccum()
+        accum = DomainAccumulator()
         accum.sources.add("ct_subsidiary_match")
         accum.resolves = True
         score = s._score_confidence(accum, "Test Co", [])


### PR DESCRIPTION
### What: 
Extracted the complex confidence scoring logic from the `Scout` orchestrator into a dedicated `ConfidenceScorer` strategy class located in `domain_scout/matching/scoring.py`. Additionally, the intermediate data structure `_DomainAccum` was moved to `domain_scout/models.py`, renamed to `DomainAccumulator`, and associated time-processing helpers were also relocated to `models.py`.

### Why:
The `_score_confidence` method was identified as a code health issue due to its high complexity, mixing heuristic rules with learned model bridge logic. By extracting this into a dedicated class, we improve the maintainability and readability of the `Scout` class and make the scoring logic more easily testable and extensible. Centralizing the `DomainAccumulator` in `models.py` better aligns with the project's data modeling patterns.

### Verification:
- Created and executed a custom verification script (`verify_scoring.py`) that mocks internal and external dependencies to validate that the `ConfidenceScorer` correctly implements the heuristic scoring levels.
- Updated `domain_scout/tests/test_multi_seed.py` and `domain_scout/tests/test_subsidiary.py` to ensure they use the refactored `DomainAccumulator` and import it from the correct location.
- Manually reviewed the refactored `Scout` class to ensure delegation to the new scorer is correct.

### Result:
Improved codebase architecture with a clear separation between search orchestration and confidence scoring. The `Scout` class is now significantly leaner and more focused on its primary responsibility.

---
*PR created automatically by Jules for task [12043741557750983470](https://jules.google.com/task/12043741557750983470) started by @minghsuy*