### PR TITLE
🧪 [add tests for _clean_name utility]

### DIFF
--- a/domain_scout/tests/test_scorer.py
+++ b/domain_scout/tests/test_scorer.py
@@ -1,0 +1,27 @@
+"""Unit tests for the scorer module."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain_scout.scorer import _clean_name
+
+
+@pytest.mark.parametrize(
+    ("input_name", "expected"),
+    [
+        ("Apple Inc", "apple"),
+        ("Microsoft Corp.", "microsoft"),
+        ("Stripe, Inc.", "stripe"),
+        ("A B C Data", "data"),
+        ("TeStinG LLC", "testing"),
+        ("   ", ""),
+        ("Data    Systems", "data systems"),
+        ("The Company Inc", ""),
+        ("Foo Ltd, Bar LLC", "foo bar"),
+        ("a", ""),
+        ("ab", ""),
+    ],
+)
+def test_clean_name(input_name: str, expected: str) -> None:
+    assert _clean_name(input_name) == expected


### PR DESCRIPTION
🎯 **What:** The `_clean_name` utility in `domain_scout/scorer/__init__.py` was untested. A pure string manipulation function should have solid tests to ensure it behaves correctly across various input scenarios.

📊 **Coverage:** A new test file `domain_scout/tests/test_scorer.py` was created to test `_clean_name` covering:
- Basic company names (e.g., "Apple Inc")
- Dropping common suffixes defined in `_COMPANY_SUFFIX_SKIP` (e.g., "Corp", "LLC")
- Stripping trailing punctuation (e.g., "Stripe, Inc.")
- Dropping short tokens under 2 characters (e.g., "A B C Data")
- Lowercasing and handling multiple spaces
- Handling empty strings or entirely skipped words

✨ **Result:** Test coverage improved for the scorer utility functions. The tests are deterministic, focused, and verified to pass successfully.

---
*PR created automatically by Jules for task [4740320080957815645](https://jules.google.com/task/4740320080957815645) started by @minghsuy*