### PR TITLE
Release v0.10.0: server-default env vars for API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Server-default environment variables** for API deployment: `DOMAIN_SCOUT_WAREHOUSE_PATH`, `DOMAIN_SCOUT_SUBSIDIARIES_PATH`, `DOMAIN_SCOUT_LOCAL_MODE` (#116)
+- **Server-default environment variables** for API deployment: `DOMAIN_SCOUT_WAREHOUSE_PATH`, `DOMAIN_SCOUT_SUBSIDIARIES_PATH`, `DOMAIN_SCOUT_LOCAL_MODE` (#117)
 - `subsidiaries_path` field on `/scan` request body
 - Auto-enable `local_first` when `DOMAIN_SCOUT_WAREHOUSE_PATH` is set without explicit mode
 - `_reject_traversal()` helper for centralized path validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-03-21
+
+### Added
+
+- **Server-default environment variables** for API deployment: `DOMAIN_SCOUT_WAREHOUSE_PATH`, `DOMAIN_SCOUT_SUBSIDIARIES_PATH`, `DOMAIN_SCOUT_LOCAL_MODE` (#116)
+- `subsidiaries_path` field on `/scan` request body
+- Auto-enable `local_first` when `DOMAIN_SCOUT_WAREHOUSE_PATH` is set without explicit mode
+- `_reject_traversal()` helper for centralized path validation
+
+### Changed
+
+- `ScanRequest.local_mode` defaults to `None` (server default) instead of `"disabled"` — backward compatible
+- `get_app()` uses `typing.get_args(LocalMode)` for forward-compatible mode validation
+
+### Fixed
+
+- Explicit `DOMAIN_SCOUT_LOCAL_MODE=disabled` is now respected when warehouse path is also configured
+
 ## [0.9.0] - 2026-03-21
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,6 +227,29 @@ domain-scout serve --port 8080
 domain-scout serve --port 8080 --api-key YOUR_KEY  # require authentication
 ```
 
+### Server environment variables
+
+Configure server-wide defaults so clients don't need to pass paths per request:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DOMAIN_SCOUT_WAREHOUSE_PATH` | Path to parquet warehouse directory | None |
+| `DOMAIN_SCOUT_SUBSIDIARIES_PATH` | Path to subsidiaries CSV file | None |
+| `DOMAIN_SCOUT_LOCAL_MODE` | `disabled`, `local_only`, or `local_first` | `disabled` (auto-enables `local_first` if warehouse path is set) |
+| `DOMAIN_SCOUT_API_KEY` | Require this key on authenticated endpoints | None |
+| `DOMAIN_SCOUT_CACHE` | Enable DuckDB cache (`true`/`false`) | `true` |
+| `DOMAIN_SCOUT_CACHE_DIR` | DuckDB cache directory | System default |
+| `DOMAIN_SCOUT_MAX_CONCURRENT` | Max concurrent scans | `3` |
+
+Example deployment with warehouse:
+
+```bash
+export DOMAIN_SCOUT_WAREHOUSE_PATH=/opt/ct-warehouse
+export DOMAIN_SCOUT_API_KEY=secret
+domain-scout serve --port 8080
+# Server auto-enables local_first mode — clients just POST to /scan
+```
+
 ### Endpoints
 
 | Method | Path | Description |
@@ -245,13 +268,31 @@ Authenticated endpoints (`/scan`, `/diff`, `/cache/*`) require `X-API-Key` heade
 
 ```json
 {
-  "company_name": "Shelter Insurance",
-  "seed_domain": ["shelterinsurance.com"],
-  "discovery_mode": "fingerprint",
-  "location": null,
-  "industry": null
+  "entity": {
+    "company_name": "Shelter Insurance",
+    "seed_domain": ["shelterinsurance.com"]
+  },
+  "profile": "balanced",
+  "timeout": 120,
+  "deep": false,
+  "local_mode": null,
+  "warehouse_path": null,
+  "subsidiaries_path": null
 }
 ```
+
+Only `entity.company_name` is required. All other fields are optional:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profile` | `broad` \| `balanced` \| `strict` | Threshold preset |
+| `timeout` | `5-300` | Override total timeout (seconds) |
+| `deep` | `bool` | Enable GeoDNS deep mode |
+| `local_mode` | `disabled` \| `local_only` \| `local_first` \| `null` | Override server default |
+| `warehouse_path` | `string` \| `null` | Override server default warehouse path |
+| `subsidiaries_path` | `string` \| `null` | Override server default subsidiaries path |
+
+When `local_mode`, `warehouse_path`, or `subsidiaries_path` are `null` (or omitted), the server's environment variable defaults are used.
 
 Returns a `ScoutResult` JSON object.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -235,7 +235,7 @@ Configure server-wide defaults so clients don't need to pass paths per request:
 |----------|-------------|---------|
 | `DOMAIN_SCOUT_WAREHOUSE_PATH` | Path to parquet warehouse directory | None |
 | `DOMAIN_SCOUT_SUBSIDIARIES_PATH` | Path to subsidiaries CSV file | None |
-| `DOMAIN_SCOUT_LOCAL_MODE` | `disabled`, `local_only`, or `local_first` | `disabled` (auto-enables `local_first` if warehouse path is set) |
+| `DOMAIN_SCOUT_LOCAL_MODE` | `disabled`, `local_only`, or `local_first` | `disabled` (auto-enables `local_first` if warehouse path is set and no explicit mode is given) |
 | `DOMAIN_SCOUT_API_KEY` | Require this key on authenticated endpoints | None |
 | `DOMAIN_SCOUT_CACHE` | Enable DuckDB cache (`true`/`false`) | `true` |
 | `DOMAIN_SCOUT_CACHE_DIR` | DuckDB cache directory | System default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "domain-scout-ct"
-version = "0.9.0"
+version = "0.10.0"
 description = "Discover internet domains associated with a business entity via CT logs, RDAP, and DNS"
 requires-python = ">=3.12"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "domain-scout-ct"
-version = "0.7.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Summary
- Version bump to 0.10.0
- Changelog for #116 (server-default env vars, auto-enable logic fix)
- REST API docs: env var table, updated `/scan` request schema with new optional fields

## Test plan
- [x] 28 tests passing
- [x] Lint clean
- [x] Docs build (MkDocs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)