### PR TITLE
Add public RDAP extract functions and get_full_info()

### DIFF
--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -295,7 +295,7 @@ class RDAPLookup:
 
         Keys: org, name, country, registrar, created_date, expiry_date,
         nameservers (list[str]), raw (dict).  On any exception returns all
-        None values with an empty nameservers list.
+        None values with an empty nameservers list and raw as {}.
         """
         try:
             data = await self._query(domain)
@@ -327,7 +327,11 @@ class RDAPLookup:
 
 
 def extract_registrar(data: dict[str, object]) -> str | None:
-    """Extract registrar name from RDAP entities vcard."""
+    """Extract registrar name from RDAP entities vcard.
+
+    Only searches top-level entities (no recursive walk into children).
+    Registrars are virtually always top-level in IANA-conformant responses.
+    """
     for entity in _safe_list(data.get("entities", [])):
         if not isinstance(entity, dict):
             continue

--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -289,3 +289,95 @@ class RDAPLookup:
                 if isinstance(country, str):
                     return country
         return None
+
+    async def get_full_info(self, domain: str) -> dict[str, object]:
+        """Return a full RDAP info dict for a domain.
+
+        Keys: org, name, country, registrar, created_date, expiry_date,
+        nameservers (list[str]), raw (dict).  On any exception returns all
+        None values with an empty nameservers list.
+        """
+        try:
+            data = await self._query(domain)
+        except Exception as exc:
+            inc(SOURCE_ERRORS_TOTAL, source="rdap")
+            log.warning("rdap.lookup_failed", domain=domain, error=str(exc))
+            return {
+                "org": None,
+                "name": None,
+                "country": None,
+                "registrar": None,
+                "created_date": None,
+                "expiry_date": None,
+                "nameservers": [],
+                "raw": {},
+            }
+
+        created_date, expiry_date = extract_dates(data)
+        return {
+            "org": self._extract_org(data),
+            "name": self._extract_name(data),
+            "country": self._extract_country(data),
+            "registrar": extract_registrar(data),
+            "created_date": created_date,
+            "expiry_date": expiry_date,
+            "nameservers": extract_nameservers(data),
+            "raw": data,
+        }
+
+
+def extract_registrar(data: dict[str, object]) -> str | None:
+    """Extract registrar name from RDAP entities vcard."""
+    for entity in _safe_list(data.get("entities", [])):
+        if not isinstance(entity, dict):
+            continue
+        if "registrar" not in _safe_list(entity.get("roles", [])):
+            continue
+        raw_vcard = entity.get("vcardArray")
+        if not isinstance(raw_vcard, list) or len(raw_vcard) < 2:
+            continue
+        for entry in _safe_list(raw_vcard[1]):
+            if not isinstance(entry, list) or len(entry) < 4:
+                continue
+            if entry[0] == "fn":
+                val = entry[3]
+                if isinstance(val, str):
+                    s = val.strip()
+                    return s if s else None
+    return None
+
+
+def extract_dates(data: dict[str, object]) -> tuple[str | None, str | None]:
+    """Extract registration and expiry dates from RDAP events.
+
+    Returns (created_date, expiry_date); either may be None.
+    """
+    created_date: str | None = None
+    expiry_date: str | None = None
+    for event in _safe_list(data.get("events", [])):
+        if not isinstance(event, dict):
+            continue
+        action = event.get("eventAction")
+        date = event.get("eventDate")
+        if not isinstance(date, str):
+            continue
+        date = date.strip()
+        if not date:
+            continue
+        if action == "registration":
+            created_date = date
+        elif action == "expiration":
+            expiry_date = date
+    return created_date, expiry_date
+
+
+def extract_nameservers(data: dict[str, object]) -> list[str]:
+    """Extract nameserver ldhName hostnames, lowercased."""
+    result: list[str] = []
+    for ns in _safe_list(data.get("nameservers", [])):
+        if not isinstance(ns, dict):
+            continue
+        ldh = ns.get("ldhName")
+        if isinstance(ldh, str) and ldh.strip():
+            result.append(ldh.strip().lower())
+    return result

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -9,7 +9,14 @@ import httpx
 import pytest
 
 from domain_scout.config import ScoutConfig
-from domain_scout.sources.rdap import RDAP_SKIP_TLDS, RDAPLookup, _RDAPCircuitBreaker
+from domain_scout.sources.rdap import (
+    RDAP_SKIP_TLDS,
+    RDAPLookup,
+    _RDAPCircuitBreaker,
+    extract_dates,
+    extract_nameservers,
+    extract_registrar,
+)
 
 
 def _make_httpx_mock(json_payload: Any = None, status_code: int = 200) -> AsyncMock:
@@ -463,3 +470,183 @@ class TestRDAPRateLimiting:
         config = ScoutConfig(max_rdap_concurrent=2)
         RDAPLookup(config)
         assert RDAPLookup._semaphore is not None
+
+
+class TestExtractRegistrar:
+    """Tests for extract_registrar()."""
+
+    def test_normal_case(self) -> None:
+        data: dict[str, object] = {
+            "entities": [
+                {
+                    "roles": ["registrar"],
+                    "vcardArray": [
+                        "vcard",
+                        [["fn", {}, "text", "GoDaddy LLC"]],
+                    ],
+                }
+            ]
+        }
+        assert extract_registrar(data) == "GoDaddy LLC"
+
+    def test_no_registrar_entity(self) -> None:
+        data: dict[str, object] = {
+            "entities": [
+                {
+                    "roles": ["registrant"],
+                    "vcardArray": ["vcard", [["fn", {}, "text", "Some Corp"]]],
+                }
+            ]
+        }
+        assert extract_registrar(data) is None
+
+    def test_empty_dict(self) -> None:
+        assert extract_registrar({}) is None
+
+    def test_short_vcard_field(self) -> None:
+        # vcard entry with fewer than 4 elements — should be skipped
+        data: dict[str, object] = {
+            "entities": [
+                {
+                    "roles": ["registrar"],
+                    "vcardArray": ["vcard", [["fn", {}]]],
+                }
+            ]
+        }
+        assert extract_registrar(data) is None
+
+
+class TestExtractDates:
+    """Tests for extract_dates()."""
+
+    def test_both_dates_present(self) -> None:
+        data: dict[str, object] = {
+            "events": [
+                {"eventAction": "registration", "eventDate": "2010-01-15T00:00:00Z"},
+                {"eventAction": "expiration", "eventDate": "2030-01-15T00:00:00Z"},
+            ]
+        }
+        created, expiry = extract_dates(data)
+        assert created == "2010-01-15T00:00:00Z"
+        assert expiry == "2030-01-15T00:00:00Z"
+
+    def test_only_registration(self) -> None:
+        data: dict[str, object] = {
+            "events": [
+                {"eventAction": "registration", "eventDate": "2010-01-15T00:00:00Z"},
+            ]
+        }
+        created, expiry = extract_dates(data)
+        assert created == "2010-01-15T00:00:00Z"
+        assert expiry is None
+
+    def test_no_events(self) -> None:
+        assert extract_dates({}) == (None, None)
+
+    def test_empty_date_strings_skipped(self) -> None:
+        data: dict[str, object] = {
+            "events": [
+                {"eventAction": "registration", "eventDate": "   "},
+                {"eventAction": "expiration", "eventDate": ""},
+            ]
+        }
+        assert extract_dates(data) == (None, None)
+
+
+class TestExtractNameservers:
+    """Tests for extract_nameservers()."""
+
+    def test_normal_case(self) -> None:
+        data: dict[str, object] = {
+            "nameservers": [
+                {"ldhName": "NS1.EXAMPLE.COM"},
+                {"ldhName": "ns2.example.com"},
+            ]
+        }
+        assert extract_nameservers(data) == ["ns1.example.com", "ns2.example.com"]
+
+    def test_empty_nameservers(self) -> None:
+        assert extract_nameservers({"nameservers": []}) == []
+        assert extract_nameservers({}) == []
+
+    def test_entries_without_ldh_name(self) -> None:
+        data: dict[str, object] = {
+            "nameservers": [
+                {"ldhName": "ns1.example.com"},
+                {"handle": "no-ldh-here"},
+                {"ldhName": "NS3.EXAMPLE.COM"},
+            ]
+        }
+        assert extract_nameservers(data) == ["ns1.example.com", "ns3.example.com"]
+
+
+class TestGetFullInfo:
+    """Tests for RDAPLookup.get_full_info()."""
+
+    def setup_method(self) -> None:
+        RDAPLookup._breaker = None
+        RDAPLookup._semaphore = None
+
+    def teardown_method(self) -> None:
+        RDAPLookup._breaker = None
+        RDAPLookup._semaphore = None
+
+    @pytest.mark.asyncio
+    async def test_success_all_fields(self) -> None:
+        config = ScoutConfig()
+        rdap = RDAPLookup(config)
+
+        mock_data: dict[str, object] = {
+            "entities": [
+                {
+                    "roles": ["registrant"],
+                    "vcardArray": [
+                        "vcard",
+                        [
+                            ["org", {}, "text", "Example Corp"],
+                            ["fn", {}, "text", "Jane Doe"],
+                            ["adr", {}, "text", ["", "", "", "", "", "", "US"]],
+                        ],
+                    ],
+                },
+                {
+                    "roles": ["registrar"],
+                    "vcardArray": ["vcard", [["fn", {}, "text", "GoDaddy"]]],
+                },
+            ],
+            "events": [
+                {"eventAction": "registration", "eventDate": "2005-05-01T00:00:00Z"},
+                {"eventAction": "expiration", "eventDate": "2025-05-01T00:00:00Z"},
+            ],
+            "nameservers": [{"ldhName": "NS1.GODADDY.COM"}],
+        }
+
+        mock_client = _make_httpx_mock(mock_data)
+        with patch("domain_scout.sources.rdap.httpx.AsyncClient", return_value=mock_client):
+            result = await rdap.get_full_info("example.com")
+
+        assert result["org"] == "Example Corp"
+        assert result["name"] == "Jane Doe"
+        assert result["country"] == "US"
+        assert result["registrar"] == "GoDaddy"
+        assert result["created_date"] == "2005-05-01T00:00:00Z"
+        assert result["expiry_date"] == "2025-05-01T00:00:00Z"
+        assert result["nameservers"] == ["ns1.godaddy.com"]
+        assert result["raw"] is mock_data
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_null_dict(self) -> None:
+        config = ScoutConfig()
+        rdap = RDAPLookup(config)
+
+        mock_client = _make_httpx_mock(status_code=500)
+        with patch("domain_scout.sources.rdap.httpx.AsyncClient", return_value=mock_client):
+            result = await rdap.get_full_info("fail.com")
+
+        assert result["org"] is None
+        assert result["name"] is None
+        assert result["country"] is None
+        assert result["registrar"] is None
+        assert result["created_date"] is None
+        assert result["expiry_date"] is None
+        assert result["nameservers"] == []

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -650,3 +650,4 @@ class TestGetFullInfo:
         assert result["created_date"] is None
         assert result["expiry_date"] is None
         assert result["nameservers"] == []
+        assert result["raw"] == {}


### PR DESCRIPTION
## Summary

- Add `extract_registrar()`, `extract_dates()`, `extract_nameservers()` as public module-level functions in `domain_scout/sources/rdap.py`
- Add `get_full_info()` instance method on `RDAPLookup` — single `_query()` call returning org, name, country, registrar, dates, nameservers, raw dict
- Proper error handling: logs warning, increments `SOURCE_ERRORS_TOTAL`, returns all-None on failure
- 13 new tests (40 total in test_rdap.py)

Needed by ct-entity-resolution#53 (RDAP cache) to avoid calling private `_query`/`_extract_*` methods.

## Test plan

- [x] `uv run pytest domain_scout/tests/test_rdap.py -v` — 40/40 pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.ai/code)