### PR TITLE
Fix RDAP semaphore bound to wrong event loop in batch calls

### DIFF
--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -139,6 +139,7 @@ class RDAPLookup:
     # log a warning if their config differs.
     _breaker: _RDAPCircuitBreaker | None = None
     _semaphore: asyncio.Semaphore | None = None
+    _semaphore_loop_id: int | None = None
     _init_concurrency: int | None = None
 
     def __init__(self, config: ScoutConfig) -> None:
@@ -183,6 +184,21 @@ class RDAPLookup:
             "country": self._extract_country(data),
         }
 
+    @classmethod
+    def _ensure_semaphore(cls) -> asyncio.Semaphore:
+        """Ensure semaphore belongs to the current event loop.
+
+        When Scout.discover() calls asyncio.run() in a loop, each call
+        creates a new event loop. A Semaphore from a previous loop raises
+        "bound to a different event loop". Detect this and recreate.
+        """
+        loop_id = id(asyncio.get_running_loop())
+        if cls._semaphore is None or cls._semaphore_loop_id != loop_id:
+            concurrency = cls._init_concurrency or 5
+            cls._semaphore = asyncio.Semaphore(concurrency)
+            cls._semaphore_loop_id = loop_id
+        return cls._semaphore
+
     async def _query(self, domain: str) -> dict[str, object]:
         tld = domain.rsplit(".", 1)[-1].lower()
         if tld in RDAP_SKIP_TLDS:
@@ -190,8 +206,8 @@ class RDAPLookup:
             return {}
 
         breaker = RDAPLookup._breaker
-        semaphore = RDAPLookup._semaphore
-        assert breaker is not None and semaphore is not None  # set in __init__
+        semaphore = self._ensure_semaphore()
+        assert breaker is not None
 
         if not breaker.should_allow():
             log.warning("rdap.circuit_open_skip", domain=domain)

--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -144,8 +144,9 @@ class RDAPLookup:
 
     def __init__(self, config: ScoutConfig) -> None:
         self._cfg = config
-        if RDAPLookup._semaphore is None:
-            RDAPLookup._semaphore = asyncio.Semaphore(config.max_rdap_concurrent)
+        # Store concurrency for _ensure_semaphore (semaphore created lazily
+        # in the correct event loop, not here).
+        if RDAPLookup._init_concurrency is None:
             RDAPLookup._init_concurrency = config.max_rdap_concurrent
         elif RDAPLookup._init_concurrency != config.max_rdap_concurrent:
             log.warning(

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -388,11 +389,15 @@ class TestRDAPRateLimiting:
         """Reset class-level state between tests."""
         RDAPLookup._breaker = None
         RDAPLookup._semaphore = None
+        RDAPLookup._semaphore_loop_id = None
+        RDAPLookup._init_concurrency = None
 
     def teardown_method(self) -> None:
         """Clean up class-level state after each test."""
         RDAPLookup._breaker = None
         RDAPLookup._semaphore = None
+        RDAPLookup._semaphore_loop_id = None
+        RDAPLookup._init_concurrency = None
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_skips_when_open(self) -> None:
@@ -457,9 +462,23 @@ class TestRDAPRateLimiting:
             assert RDAPLookup._breaker is not None
             assert RDAPLookup._breaker.state == "open"
 
-    @pytest.mark.asyncio
-    async def test_semaphore_initialized(self) -> None:
-        """Semaphore is created with configured concurrency."""
+    def test_init_does_not_create_semaphore(self) -> None:
+        """Semaphore is created lazily in _ensure_semaphore, not __init__."""
         config = ScoutConfig(max_rdap_concurrent=2)
         RDAPLookup(config)
+        # Semaphore should NOT be created in __init__ — it must be created
+        # in the correct event loop by _ensure_semaphore.
+        assert RDAPLookup._semaphore is None
+        assert RDAPLookup._init_concurrency == 2
+
+    @pytest.mark.asyncio
+    async def test_semaphore_bound_to_current_loop(self) -> None:
+        """Regression: semaphore must belong to the running event loop."""
+        config = ScoutConfig(max_rdap_concurrent=2)
+        rdap = RDAPLookup(config)
+        mock_client = _make_httpx_mock(json_payload={"entities": []})
+        with patch("domain_scout.sources.rdap.httpx.AsyncClient", return_value=mock_client):
+            await rdap.get_registrant_org("example.com")
+        # Semaphore should now exist and be bound to current loop
         assert RDAPLookup._semaphore is not None
+        assert RDAPLookup._semaphore_loop_id == id(asyncio.get_running_loop())


### PR DESCRIPTION
## Summary

When `Scout.discover()` is called in a loop, each `asyncio.run()` creates a new event loop. The class-level `Semaphore` stayed bound to the first (now dead) loop, causing `"bound to a different event loop"` on every subsequent RDAP lookup.

Fix: `_ensure_semaphore()` checks if the current running loop matches the one the semaphore was created on. If not, recreates it. Uses `asyncio.get_running_loop()` (Python 3.10+).

Note: RDAP registrant data is largely redacted due to GDPR/registrar privacy policies (berkley.com, allstate.com, allianz.com all return org=None). The fix is correct but the data source has limited value currently.

## Test plan

- [x] 576 tests pass, 0 failures
- [x] Manual test: 3 consecutive `Scout.discover()` calls — zero RDAP warnings (previously every call after the first warned)
- [x] `RDAPLookup.get_registrant_info()` called directly across fresh `asyncio.run()` loops — works

🤖 Generated with [Claude Code](https://claude.com/claude-code)