### PR TITLE
Improve evidence quality: dedup, RDAP for subsidiaries, context

### DIFF
--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -26,6 +26,8 @@ class EvidenceRecord(BaseModel):
     cert_org: str | None = None
     similarity_score: float | None = None
     rdap_org: str | None = None
+    signal_type: str | None = None
+    signal_weight: float | None = None
 
 
 class DiscoveredDomain(BaseModel):

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -770,7 +770,13 @@ class Scout:
                 continue
             accum = _DomainAccum()
             accum.sources.add(source_tag)
-            desc = f"Cert org '{cert_org}' matches target (score={similarity:.2f})"
+            if source_tag in ("ct_subsidiary_match", "ct_gleif_subsidiary"):
+                desc = (
+                    f"Cert org '{cert_org}' matches subsidiary "
+                    f"'{org_name}' (score={similarity:.2f})"
+                )
+            else:
+                desc = f"Cert org '{cert_org}' matches target (score={similarity:.2f})"
             accum.evidence.append(
                 EvidenceRecord(
                     source_type=source_tag,
@@ -1147,8 +1153,19 @@ class Scout:
                 rdap_org = await self._rdap.get_registrant_org(domain)
                 if not rdap_org:
                     return
-                sim = org_name_similarity(rdap_org, company_name)
-                if sim < self.config.org_match_threshold:
+
+                # Check against query entity first, then any cert org names
+                # (covers GLEIF subsidiaries whose registrant matches the
+                # subsidiary name rather than the parent query entity).
+                best_sim = org_name_similarity(rdap_org, company_name)
+                matched_name = company_name
+                for cert_org in accum.cert_org_names:
+                    s = org_name_similarity(rdap_org, cert_org)
+                    if s > best_sim:
+                        best_sim = s
+                        matched_name = cert_org
+
+                if best_sim < self.config.org_match_threshold:
                     return
 
                 accum.sources.add("rdap_registrant_match")
@@ -1157,10 +1174,11 @@ class Scout:
                     EvidenceRecord(
                         source_type="rdap_registrant_match",
                         description=(
-                            f"RDAP registrant '{rdap_org}' matches target (score={sim:.2f})"
+                            f"RDAP registrant '{rdap_org}' matches "
+                            f"'{matched_name}' (score={best_sim:.2f})"
                         ),
                         rdap_org=rdap_org,
-                        similarity_score=round(sim, 4),
+                        similarity_score=round(best_sim, 4),
                     )
                 )
             except Exception as exc:
@@ -1324,14 +1342,27 @@ class Scout:
 
             contributing_seeds = sorted(_extract_contributing_seeds(accum.sources))
 
-            # Deduplicate evidence records
-            seen: set[tuple[str, str | None, int | None]] = set()
+            # Deduplicate evidence records: for cert-org evidence, group by
+            # (source_type, cert_org) and keep the best similarity score.
+            # For other evidence types, dedup by (source_type, seed_domain).
             deduped: list[EvidenceRecord] = []
+            seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
+            seen_other: set[tuple[str, str | None]] = set()
             for ev in accum.evidence:
-                key = (ev.source_type, ev.seed_domain, ev.cert_id)
-                if key not in seen:
-                    seen.add(key)
-                    deduped.append(ev)
+                if ev.cert_org is not None:
+                    key = (ev.source_type, ev.cert_org)
+                    existing = seen_org.get(key)
+                    if existing is None or (
+                        ev.similarity_score is not None
+                        and (existing.similarity_score or 0) < ev.similarity_score
+                    ):
+                        seen_org[key] = ev
+                else:
+                    key_other = (ev.source_type, ev.seed_domain)
+                    if key_other not in seen_other:
+                        seen_other.add(key_other)
+                        deduped.append(ev)
+            deduped.extend(seen_org.values())
 
             domains.append(
                 DiscoveredDomain(

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -52,6 +52,30 @@ from domain_scout.sources.rdap import RDAPLookup
 log = structlog.get_logger()
 _TOOL_VERSION = _pkg_version("domain-scout-ct")
 
+# Signal classification for evidence transparency.
+# Maps source_type prefixes to (signal_type, weight).
+_SIGNAL_MAP: dict[str, tuple[str, float]] = {
+    "ct_org_match": ("cert_org_match", 0.80),
+    "ct_subsidiary_match": ("cert_org_subsidiary", 0.50),
+    "ct_gleif_subsidiary": ("cert_org_subsidiary", 0.50),
+    "ct_san_expansion": ("san_co_occurrence", 0.40),
+    "ct_seed_subdomain": ("seed_subdomain", 0.30),
+    "ct_seed_related": ("seed_related", 0.15),
+    "dns_guess": ("dns_guess", 0.20),
+    "cross_seed_verified": ("cross_seed", 0.90),
+    "rdap_registrant_match": ("rdap_registrant", 0.45),
+    "shared_infra": ("shared_infrastructure", 0.10),
+    "geodns": ("geodns_rescue", 0.10),
+}
+
+
+def _signal_fields(source_tag: str) -> dict[str, Any]:
+    """Return signal_type and signal_weight for a source tag."""
+    sig = _SIGNAL_MAP.get(source_tag.split(":")[0])
+    if sig is None:
+        return {}
+    return {"signal_type": sig[0], "signal_weight": sig[1]}
+
 
 def load_subsidiary_map(csv_path: str) -> dict[str, list[str]]:
     """Load parent→subsidiary mappings from a corporate subsidiaries CSV.
@@ -568,6 +592,7 @@ class Scout:
                             EvidenceRecord(
                                 source_type="geodns",
                                 description="Resolved via Shodan GeoDNS (global)",
+                                **_signal_fields("geodns"),
                             )
                         )
                         log.info("scout.geodns_rescued", domain=domain)
@@ -784,6 +809,7 @@ class Scout:
                     cert_id=_int_or_none(rec.get("cert_id")),
                     cert_org=cert_org,
                     similarity_score=round(similarity, 4),
+                    **_signal_fields(source_tag),
                 )
             )
             accum.cert_org_names.add(cert_org)
@@ -870,6 +896,7 @@ class Scout:
                             source_type="ct_seed_subdomain",
                             description=f"Subdomain of seed domain {seed_domain}",
                             seed_domain=seed_domain,
+                            **_signal_fields("ct_seed_subdomain"),
                         )
                     )
                 elif has_seed_san:
@@ -882,6 +909,7 @@ class Scout:
                             source_type="ct_san_expansion",
                             description=f"Found on same cert as seed domain {seed_domain}",
                             seed_domain=seed_domain,
+                            **_signal_fields("ct_san_expansion"),
                         )
                     )
                 else:
@@ -891,6 +919,7 @@ class Scout:
                             source_type="ct_seed_related",
                             description=f"Found in CT search for {seed_domain}",
                             seed_domain=seed_domain,
+                            **_signal_fields("ct_seed_related"),
                         )
                     )
 
@@ -907,6 +936,7 @@ class Scout:
                                 cert_id=_int_or_none(rec.get("cert_id")),
                                 cert_org=cert_org,
                                 similarity_score=round(sim, 4),
+                                **_signal_fields("ct_org_match"),
                             )
                         )
 
@@ -953,6 +983,7 @@ class Scout:
                 EvidenceRecord(
                     source_type="dns_guess",
                     description="Guessed from company name, resolves in DNS",
+                    **_signal_fields("dns_guess"),
                 )
             )
             accum.resolves = True
@@ -982,6 +1013,7 @@ class Scout:
                     EvidenceRecord(
                         source_type="cross_seed_verified",
                         description=f"Cross-verified: found from seeds {seeds_str}",
+                        **_signal_fields("cross_seed_verified"),
                     )
                 )
 
@@ -1112,6 +1144,7 @@ class Scout:
                     EvidenceRecord(
                         source_type="shared_infra",
                         description=f"Shares infrastructure with {reference}",
+                        **_signal_fields("shared_infra"),
                     )
                 )
                 # Cap so infra boost can't exceed the +0.10 total boost limit.
@@ -1179,6 +1212,7 @@ class Scout:
                         ),
                         rdap_org=rdap_org,
                         similarity_score=round(best_sim, 4),
+                        **_signal_fields("rdap_registrant_match"),
                     )
                 )
             except Exception as exc:
@@ -1309,6 +1343,7 @@ class Scout:
                             source_type=source_tag,
                             description=sig_desc.get(sig.signal_type, _fallback)(sig),
                             seed_domain=best_match.seed_domain,
+                            **_signal_fields(source_tag),
                         )
                     )
 

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -1187,12 +1187,20 @@ class Scout:
                 if not rdap_org:
                     return
 
-                # Check against query entity first, then any cert org names
-                # (covers GLEIF subsidiaries whose registrant matches the
-                # subsidiary name rather than the parent query entity).
+                # Check against query entity first, then cert org names from
+                # org-match strategies only (not SAN expansion, which could
+                # introduce transitive attribution from shared certs).
                 best_sim = org_name_similarity(rdap_org, company_name)
                 matched_name = company_name
-                for cert_org in accum.cert_org_names:
+                _ORG_MATCH_TAGS = frozenset(
+                    {"ct_org_match", "ct_subsidiary_match", "ct_gleif_subsidiary"}
+                )
+                org_matched_orgs = {
+                    ev.cert_org
+                    for ev in accum.evidence
+                    if ev.source_type in _ORG_MATCH_TAGS and ev.cert_org
+                }
+                for cert_org in org_matched_orgs:
                     s = org_name_similarity(rdap_org, cert_org)
                     if s > best_sim:
                         best_sim = s
@@ -1398,6 +1406,7 @@ class Scout:
                         seen_other.add(key_other)
                         deduped.append(ev)
             deduped.extend(seen_org.values())
+            deduped.sort(key=lambda e: (e.source_type, e.cert_org or ""))
 
             domains.append(
                 DiscoveredDomain(

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -69,12 +69,42 @@ _SIGNAL_MAP: dict[str, tuple[str, float]] = {
 }
 
 
+# Source tags that represent org-name-matched evidence (not SAN expansion).
+_ORG_MATCH_TAGS = frozenset({"ct_org_match", "ct_subsidiary_match", "ct_gleif_subsidiary"})
+
+
 def _signal_fields(source_tag: str) -> dict[str, Any]:
     """Return signal_type and signal_weight for a source tag."""
     sig = _SIGNAL_MAP.get(source_tag.split(":")[0])
     if sig is None:
         return {}
     return {"signal_type": sig[0], "signal_weight": sig[1]}
+
+
+def _dedup_evidence(evidence: list[EvidenceRecord]) -> list[EvidenceRecord]:
+    """Deduplicate evidence: group cert-org records by (source_type, cert_org),
+    keep best similarity; dedup others by (source_type, seed_domain).
+    Returns stable sorted output for deterministic serialization."""
+    deduped: list[EvidenceRecord] = []
+    seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
+    seen_other: set[tuple[str, str | None]] = set()
+    for ev in evidence:
+        if ev.cert_org is not None:
+            key = (ev.source_type, ev.cert_org)
+            existing = seen_org.get(key)
+            if existing is None or (
+                ev.similarity_score is not None
+                and (existing.similarity_score or 0) < ev.similarity_score
+            ):
+                seen_org[key] = ev
+        else:
+            key_other = (ev.source_type, ev.seed_domain)
+            if key_other not in seen_other:
+                seen_other.add(key_other)
+                deduped.append(ev)
+    deduped.extend(seen_org.values())
+    deduped.sort(key=lambda e: (e.source_type, e.cert_org or ""))
+    return deduped
 
 
 def load_subsidiary_map(csv_path: str) -> dict[str, list[str]]:
@@ -1192,9 +1222,6 @@ class Scout:
                 # introduce transitive attribution from shared certs).
                 best_sim = org_name_similarity(rdap_org, company_name)
                 matched_name = company_name
-                _ORG_MATCH_TAGS = frozenset(
-                    {"ct_org_match", "ct_subsidiary_match", "ct_gleif_subsidiary"}
-                )
                 org_matched_orgs = {
                     ev.cert_org
                     for ev in accum.evidence
@@ -1385,28 +1412,7 @@ class Scout:
 
             contributing_seeds = sorted(_extract_contributing_seeds(accum.sources))
 
-            # Deduplicate evidence records: for cert-org evidence, group by
-            # (source_type, cert_org) and keep the best similarity score.
-            # For other evidence types, dedup by (source_type, seed_domain).
-            deduped: list[EvidenceRecord] = []
-            seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
-            seen_other: set[tuple[str, str | None]] = set()
-            for ev in accum.evidence:
-                if ev.cert_org is not None:
-                    key = (ev.source_type, ev.cert_org)
-                    existing = seen_org.get(key)
-                    if existing is None or (
-                        ev.similarity_score is not None
-                        and (existing.similarity_score or 0) < ev.similarity_score
-                    ):
-                        seen_org[key] = ev
-                else:
-                    key_other = (ev.source_type, ev.seed_domain)
-                    if key_other not in seen_other:
-                        seen_other.add(key_other)
-                        deduped.append(ev)
-            deduped.extend(seen_org.values())
-            deduped.sort(key=lambda e: (e.source_type, e.cert_org or ""))
+            deduped = _dedup_evidence(accum.evidence)
 
             domains.append(
                 DiscoveredDomain(

--- a/domain_scout/tests/test_evidence.py
+++ b/domain_scout/tests/test_evidence.py
@@ -189,20 +189,19 @@ class TestSignalFields:
 class TestEvidenceDedup:
     def test_cert_org_evidence_deduped_by_org(self) -> None:
         """Multiple certs with same org collapse to one evidence record."""
-        from domain_scout.scout import _DomainAccum
+        from domain_scout.scout import _dedup_evidence
 
-        accum = _DomainAccum()
-        for i in range(10):
-            accum.evidence.append(
-                EvidenceRecord(
-                    source_type="ct_org_match",
-                    description="Cert org 'Acme Inc' matches target (score=0.95)",
-                    cert_id=i,
-                    cert_org="Acme Inc",
-                    similarity_score=0.95,
-                )
+        evidence = [
+            EvidenceRecord(
+                source_type="ct_org_match",
+                description="Cert org 'Acme Inc' matches target (score=0.95)",
+                cert_id=i,
+                cert_org="Acme Inc",
+                similarity_score=0.95,
             )
-        accum.evidence.append(
+            for i in range(10)
+        ]
+        evidence.append(
             EvidenceRecord(
                 source_type="rdap_registrant_match",
                 description="RDAP registrant 'Acme' matches target",
@@ -211,31 +210,10 @@ class TestEvidenceDedup:
             )
         )
 
-        # Can't call _build_output directly (needs full Scout), but the dedup
-        # logic is inline. Test by checking the evidence list structure.
         # 10 cert records with same (source_type, cert_org) → 1
         # 1 rdap record → 1
-        # Total should be 2
-        seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
-        deduped: list[EvidenceRecord] = []
-        seen_other: set[tuple[str, str | None]] = set()
-        for ev in accum.evidence:
-            if ev.cert_org is not None:
-                key = (ev.source_type, ev.cert_org)
-                existing = seen_org.get(key)
-                if existing is None or (
-                    ev.similarity_score is not None
-                    and (existing.similarity_score or 0) < ev.similarity_score
-                ):
-                    seen_org[key] = ev
-            else:
-                key_other = (ev.source_type, ev.seed_domain)
-                if key_other not in seen_other:
-                    seen_other.add(key_other)
-                    deduped.append(ev)
-        deduped.extend(seen_org.values())
-
-        assert len(deduped) == 2  # 1 cert-org + 1 rdap
+        deduped = _dedup_evidence(evidence)
+        assert len(deduped) == 2
 
 
 class TestConfigToDict:

--- a/domain_scout/tests/test_evidence.py
+++ b/domain_scout/tests/test_evidence.py
@@ -127,6 +127,117 @@ class TestEvidenceRecord:
 # --- Config.to_dict ---
 
 
+# --- Signal metadata ---
+
+
+class TestSignalFields:
+    def test_known_source_tag_populates_fields(self) -> None:
+        from domain_scout.scout import _signal_fields
+
+        result = _signal_fields("ct_org_match")
+        assert result["signal_type"] == "cert_org_match"
+        assert result["signal_weight"] == 0.80
+
+    def test_subsidiary_source_tag(self) -> None:
+        from domain_scout.scout import _signal_fields
+
+        result = _signal_fields("ct_gleif_subsidiary")
+        assert result["signal_type"] == "cert_org_subsidiary"
+        assert result["signal_weight"] == 0.50
+
+    def test_unknown_source_tag_returns_empty(self) -> None:
+        from domain_scout.scout import _signal_fields
+
+        result = _signal_fields("fp:mx_tenant")
+        assert result == {}
+
+    def test_colon_prefixed_tag_splits_correctly(self) -> None:
+        from domain_scout.scout import _signal_fields
+
+        # "ct_san_expansion:seed.com" should match "ct_san_expansion"
+        result = _signal_fields("ct_san_expansion:example.com")
+        assert result["signal_type"] == "san_co_occurrence"
+
+    def test_evidence_record_accepts_signal_fields(self) -> None:
+        """Signal fields unpack into EvidenceRecord without error."""
+        from domain_scout.scout import _signal_fields
+
+        ev = EvidenceRecord(
+            source_type="ct_org_match",
+            description="test",
+            **_signal_fields("ct_org_match"),
+        )
+        assert ev.signal_type == "cert_org_match"
+        assert ev.signal_weight == 0.80
+
+    def test_evidence_record_without_signal_fields(self) -> None:
+        """Empty signal fields leave signal_type/weight as None."""
+        from domain_scout.scout import _signal_fields
+
+        ev = EvidenceRecord(
+            source_type="fp:mx_tenant",
+            description="test",
+            **_signal_fields("fp:mx_tenant"),
+        )
+        assert ev.signal_type is None
+        assert ev.signal_weight is None
+
+
+# --- Evidence dedup ---
+
+
+class TestEvidenceDedup:
+    def test_cert_org_evidence_deduped_by_org(self) -> None:
+        """Multiple certs with same org collapse to one evidence record."""
+        from domain_scout.scout import _DomainAccum
+
+        accum = _DomainAccum()
+        for i in range(10):
+            accum.evidence.append(
+                EvidenceRecord(
+                    source_type="ct_org_match",
+                    description="Cert org 'Acme Inc' matches target (score=0.95)",
+                    cert_id=i,
+                    cert_org="Acme Inc",
+                    similarity_score=0.95,
+                )
+            )
+        accum.evidence.append(
+            EvidenceRecord(
+                source_type="rdap_registrant_match",
+                description="RDAP registrant 'Acme' matches target",
+                rdap_org="Acme",
+                similarity_score=0.90,
+            )
+        )
+
+        # Can't call _build_output directly (needs full Scout), but the dedup
+        # logic is inline. Test by checking the evidence list structure.
+        # 10 cert records with same (source_type, cert_org) → 1
+        # 1 rdap record → 1
+        # Total should be 2
+        seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
+        deduped: list[EvidenceRecord] = []
+        seen_other: set[tuple[str, str | None]] = set()
+        for ev in accum.evidence:
+            if ev.cert_org is not None:
+                key = (ev.source_type, ev.cert_org)
+                existing = seen_org.get(key)
+                if existing is None or (
+                    ev.similarity_score is not None
+                    and (existing.similarity_score or 0) < ev.similarity_score
+                ):
+                    seen_org[key] = ev
+            else:
+                key_other = (ev.source_type, ev.seed_domain)
+                if key_other not in seen_other:
+                    seen_other.add(key_other)
+                    deduped.append(ev)
+        deduped.extend(seen_org.values())
+
+        assert len(deduped) == 2  # 1 cert-org + 1 rdap
+
+
 class TestConfigToDict:
     def test_to_dict_has_all_fields(self) -> None:
         cfg = ScoutConfig()


### PR DESCRIPTION
## Summary
- **Evidence dedup**: Group cert-org evidence by `(source_type, cert_org)` instead of per-cert. A domain with 22 certs from the same org now shows 1 evidence record with the best similarity score, not 22 identical entries.
- **RDAP for subsidiaries**: RDAP corroboration now checks registrant against cert org names (not just the query entity). Subsidiary domains like altalink.ca match registrant "AltaLink LP" against cert org "ALTALINK, L.P." (score=1.0) instead of failing against "Berkshire Hathaway" (score=0.34).
- **Subsidiary context**: Evidence descriptions for `ct_gleif_subsidiary` and `ct_subsidiary_match` now include the subsidiary name: "matches subsidiary 'PacifiCorp'" instead of "matches target".

## Test plan
- [x] 609 tests pass, 0 regressions
- [x] mypy clean
- [x] Smoke tested: bhhc.com evidence deduped from 22 → 1 record
- [x] Verified RDAP registrant-vs-cert-org matching works (AltaLink LP → ALTALINK, L.P. = 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)