### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-01
+
+### Added
+
+- **GLEIF corporate hierarchy expansion** — `Scout.discover()` now expands queries to known subsidiaries via GLEIF corporate tree data (#122)
+  - `find_entity()`: 4-stage matching (exact → icase → prefix → fuzzy) with subsidiary-count tie-breaking
+  - `expand_corporate_tree()`: includes `IS_ULTIMATELY_CONSOLIDATED_BY` for multi-hop trees
+  - Sibling dedup penalty (-0.15) prevents cross-attribution between sister entities
+  - New `gleif` optional dependency: `pip install domain-scout-ct[gleif]`
+- **`gleif-ingest` CLI command** — downloads GLEIF golden copy from gleif.org and builds local DuckDB file
+- **`--gleif-db` CLI option** and `DOMAIN_SCOUT_GLEIF_DB` env var for specifying GLEIF database path
+- **Signal metadata on evidence** — `EvidenceRecord.signal_type` and `signal_weight` fields expose which signals contributed to confidence (#123)
+- **Subsidiary context in evidence** — descriptions for subsidiary domains now include the subsidiary name (e.g., "matches subsidiary 'PacifiCorp'") (#123)
+- **Public RDAP extract functions** — `extract_registrar()`, `extract_dates()`, `extract_nameservers()`, `get_full_info()` (#119)
+
+### Fixed
+
+- **RDAP semaphore event loop** — semaphore now created lazily in `_ensure_semaphore()` bound to the current event loop, fixing `RuntimeError` in batch/notebook contexts (#120)
+- **Evidence dedup** — cert-org evidence grouped by `(source_type, cert_org)` instead of per-cert, eliminating duplicate records (#123)
+- **RDAP for subsidiaries** — registrant checked against cert org names (not just query entity), so subsidiary domains get proper RDAP corroboration (#123)
+
 ## [0.10.0] - 2026-03-21
 
 ### Added

--- a/docs/gleif-expansion.md
+++ b/docs/gleif-expansion.md
@@ -1,0 +1,91 @@
+# GLEIF Corporate Hierarchy
+
+Scout can expand queries to a company's full corporate family using [GLEIF](https://www.gleif.org/) (Global Legal Entity Identifier Foundation) data. When you search for "Berkshire Hathaway", Scout finds domains for subsidiaries like Gen Re, PacifiCorp, and AltaLink — not just domains whose cert org fuzzy-matches the parent name.
+
+## Setup
+
+Install the GLEIF optional dependency:
+
+```bash
+pip install domain-scout-ct[gleif]
+```
+
+Download the GLEIF golden copy (~450MB download, ~650MB database):
+
+```bash
+domain-scout gleif-ingest
+```
+
+This downloads entity and relationship data from [gleif.org](https://goldencopy.gleif.org/) and builds an indexed DuckDB file at `~/.local/share/domain-scout/gleif.duckdb`.
+
+## Usage
+
+### CLI
+
+```bash
+domain-scout scout --name "Berkshire Hathaway" \
+  --gleif-db ~/.local/share/domain-scout/gleif.duckdb
+```
+
+Or set the environment variable:
+
+```bash
+export DOMAIN_SCOUT_GLEIF_DB=~/.local/share/domain-scout/gleif.duckdb
+domain-scout scout --name "Berkshire Hathaway"
+```
+
+### Python API
+
+```python
+from domain_scout.config import ScoutConfig
+from domain_scout.scout import Scout
+
+config = ScoutConfig(gleif_db_path="/path/to/gleif.duckdb")
+scout = Scout(config=config)
+result = await scout.discover_async(EntityInput(company_name="Berkshire Hathaway"))
+```
+
+## How it works
+
+1. **Entity lookup** — Scout searches GLEIF for the queried company name using 4-stage matching (exact → case-insensitive → prefix → fuzzy). Prefers entities with subsidiaries to avoid matching empty shell entities.
+
+2. **Corporate tree expansion** — Traverses parent/subsidiary/sibling relationships, including multi-hop paths via `IS_ULTIMATELY_CONSOLIDATED_BY`. For Berkshire Hathaway, this finds ~124 subsidiaries.
+
+3. **Brand filtering** — Filters subsidiaries to those with distinct brand names (removes shell companies, holding entities, and names that overlap with the parent). Typically reduces 124 raw subsidiaries to ~30 searchable brands.
+
+4. **CT search per subsidiary** — Each filtered subsidiary name triggers a certificate transparency search. Found domains are tagged with `ct_gleif_subsidiary` in the evidence chain.
+
+5. **Sibling dedup** — Domains whose cert org matches a sibling entity (not the queried entity) receive a confidence penalty to prevent cross-attribution.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `gleif_db_path` | None | Path to GLEIF DuckDB file |
+| `gleif_max_subsidiaries` | 5 | Max subsidiaries to search (depth limit) |
+
+## Evidence output
+
+Domains found via GLEIF expansion include the subsidiary name in the evidence chain:
+
+```json
+{
+  "domain": "pacificorp.com",
+  "confidence": 0.80,
+  "sources": ["ct_gleif_subsidiary"],
+  "evidence": [
+    {
+      "source_type": "ct_gleif_subsidiary",
+      "description": "Cert org 'PacifiCorp' matches subsidiary 'PacifiCorp' (score=1.00)",
+      "signal_type": "cert_org_subsidiary",
+      "signal_weight": 0.50
+    }
+  ]
+}
+```
+
+## Limitations
+
+- **GLEIF coverage is incomplete.** Many subsidiaries (especially acquired companies) don't have LEI registrations linking them to their parent. For example, GEICO has no LEI under Berkshire Hathaway.
+- **Regional offices** with the parent's name (e.g., "Palo Alto Networks (UK) Limited") are filtered out — the parent CT search already covers them.
+- **GLEIF data refreshes daily** at gleif.org. Re-run `domain-scout gleif-ingest` periodically to stay current.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Multi-Seed Discovery: multi-seed.md
   - Deep Mode: deep-mode.md
   - Fingerprint Mode: fingerprint-mode.md
+  - GLEIF Expansion: gleif-expansion.md
   - Examples: examples.md
   - API Reference: api.md
   - RDAP ccTLD Support: rdap-cctld-support.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "domain-scout-ct"
-version = "0.10.0"
+version = "0.11.0"
 description = "Discover internet domains associated with a business entity via CT logs, RDAP, and DNS"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.11.0
- CHANGELOG updated with all changes since v0.10.0

## Changes since v0.10.0
- #119 — Public RDAP extract functions
- #120 — RDAP semaphore event loop fix
- #122 — GLEIF corporate hierarchy for subsidiary discovery
- #123 — Evidence quality: dedup, signal metadata, RDAP for subsidiaries

## Post-merge
Tag `v0.11.0` on main to trigger PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)