### PR TITLE
ci: normalize bridge `if:` to single-line scalar

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,9 +37,7 @@ jobs:
   trigger-review:
     # Skip on drafts. Skip on bot-authored PRs (Dependabot, Renovate) — those
     # don't need automated AI review and would burn PAT API calls per push.
-    if: |
-      ${{ !github.event.pull_request.draft &&
-          github.event.pull_request.user.type != 'Bot' }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     # Empty permissions block: gh pr comment uses BRIDGE_PAT (not GITHUB_TOKEN),
     # so the job's GITHUB_TOKEN should have zero capability. Explicit `{}` is


### PR DESCRIPTION
Mirror of [hsa-receipt-system#47](https://github.com/minghsuy/hsa-receipt-system/pull/47). 1-line YAML normalization — collapses `if: |` block scalar to canonical single-line form. Empirically equivalent (GitHub Actions normalizes whitespace inside `${{ }}` during expression evaluation). Resolves [hsa-receipt-system#46](https://github.com/minghsuy/hsa-receipt-system/issues/46) item 1.

Bridge fires on this PR's own `synchronize` event — no `--admin` needed (validated on HSA #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)