### PR TITLE
fix(models): EntityInput accepts seed_domain-only queries

### DIFF
--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -9,16 +9,7 @@ from pydantic import BaseModel, Field, model_validator
 
 
 class EntityInput(BaseModel):
-    """Describes the business entity to search for.
-
-    Either ``company_name`` or ``seed_domain`` (or both) must be provided.
-    A pure ``seed_domain`` query (reverse-lookup: "what org owns this
-    domain?") is valid — Scout will still run domain-side signals like
-    cert-subject org extraction, RDAP registrant lookup, and DNS
-    resolution, surfacing the attributed org without needing an org-name
-    hint up front. Conversely, a pure ``company_name`` query (forward
-    discovery: "what domains belong to this org?") is the original mode.
-    """
+    """Search target: company_name (forward) or seed_domain (reverse) or both."""
 
     company_name: str = Field(default="", max_length=200)
     location: str | None = None
@@ -27,13 +18,6 @@ class EntityInput(BaseModel):
 
     @model_validator(mode="after")
     def _require_at_least_one_input(self) -> Self:
-        """Reject the empty case where neither field is provided.
-
-        ``company_name=""`` and ``seed_domain=[]`` together is a request
-        with no search target — Scout has nothing to act on, so we
-        surface the misuse at validation time rather than running an
-        empty discovery.
-        """
         if not self.company_name and not self.seed_domain:
             msg = "either company_name or seed_domain is required"
             raise ValueError(msg)

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -3,17 +3,41 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 — Pydantic needs runtime import
+from typing import Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class EntityInput(BaseModel):
-    """Describes the business entity to search for."""
+    """Describes the business entity to search for.
 
-    company_name: str = Field(min_length=1, max_length=200)
+    Either ``company_name`` or ``seed_domain`` (or both) must be provided.
+    A pure ``seed_domain`` query (reverse-lookup: "what org owns this
+    domain?") is valid — Scout will still run domain-side signals like
+    cert-subject org extraction, RDAP registrant lookup, and DNS
+    resolution, surfacing the attributed org without needing an org-name
+    hint up front. Conversely, a pure ``company_name`` query (forward
+    discovery: "what domains belong to this org?") is the original mode.
+    """
+
+    company_name: str = Field(default="", max_length=200)
     location: str | None = None
     seed_domain: list[str] = Field(default_factory=list, max_length=50)
     industry: str | None = None
+
+    @model_validator(mode="after")
+    def _require_at_least_one_input(self) -> Self:
+        """Reject the empty case where neither field is provided.
+
+        ``company_name=""`` and ``seed_domain=[]`` together is a request
+        with no search target — Scout has nothing to act on, so we
+        surface the misuse at validation time rather than running an
+        empty discovery.
+        """
+        if not self.company_name and not self.seed_domain:
+            msg = "either company_name or seed_domain is required"
+            raise ValueError(msg)
+        return self
 
 
 class EvidenceRecord(BaseModel):

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -420,8 +420,10 @@ class Scout:
         independent_tasks: list[asyncio.Task[list[tuple[str, _DomainAccum]]]] = []
 
         # Strategy A: org name search (independent of seed)
-        # Skip in fingerprint mode — DV certs have no org name, so CT org search is useless
-        if self.config.discovery_mode != "fingerprint":
+        # Skip in fingerprint mode — DV certs have no org name, so CT org search is useless.
+        # Skip on seed-only queries — empty company_name would query CT with an empty
+        # search term (massive result set or noise).
+        if self.config.discovery_mode != "fingerprint" and entity.company_name:
             independent_tasks.append(
                 asyncio.create_task(
                     self._strategy_org_search(entity.company_name, errors),
@@ -430,6 +432,7 @@ class Scout:
             )
 
         # Strategy C: domain guessing (independent of seed)
+        # Safe with empty company_name — domain_from_company_name("") returns [] early.
         independent_tasks.append(
             asyncio.create_task(
                 self._strategy_domain_guess(entity.company_name, entity.location, errors),
@@ -437,11 +440,11 @@ class Scout:
             )
         )
 
-        # Strategy D: subsidiary expansion
-        # D1: GLEIF corporate tree (if available)
+        # Strategy D: subsidiary expansion. Both GLEIF and CSV fallback need a real
+        # company name to look up — skip both on seed-only queries.
         gleif_sub_names: list[str] = []
         gleif_sibling_names: set[str] = set()
-        if self._gleif_con is not None:
+        if self._gleif_con is not None and entity.company_name:
             gleif_sub_names, gleif_sibling_names = self._expand_gleif_tree(entity.company_name)
             for sub_name in gleif_sub_names[: self.config.gleif_max_subsidiaries]:
                 independent_tasks.append(
@@ -456,7 +459,7 @@ class Scout:
                 )
 
         # D2: CSV fallback (if CSV loaded and GLEIF didn't find anything)
-        if self._subsidiaries and not gleif_sub_names:
+        if self._subsidiaries and not gleif_sub_names and entity.company_name:
             sub_names = self._match_subsidiaries(entity.company_name)
             for sub_name in sub_names[: self.config.subsidiary_max_queries]:
                 independent_tasks.append(

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -440,8 +440,7 @@ class Scout:
             )
         )
 
-        # Strategy D: subsidiary expansion. Both GLEIF and CSV fallback need a real
-        # company name to look up — skip both on seed-only queries.
+        # Strategy D: subsidiary expansion. Both GLEIF and CSV need company_name; skip on seed-only.
         gleif_sub_names: list[str] = []
         gleif_sibling_names: set[str] = set()
         if self._gleif_con is not None and entity.company_name:

--- a/domain_scout/tests/test_acceptance.py
+++ b/domain_scout/tests/test_acceptance.py
@@ -7,6 +7,7 @@ Scout level.
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -233,14 +234,12 @@ class TestSeedOnlyDiscovery:
 
         # search_by_org should never have been called — Strategy A is gated
         # on `entity.company_name`. search_by_domain is still expected to fire.
-        org_calls = [
-            call
-            for call in scout._ct.search_by_org.mock_calls
-            if call.kwargs.get("verify_org") is not False  # type: ignore[attr-defined]
-        ]
-        assert len(org_calls) == 0, (
-            f"search_by_org was called {len(org_calls)} times on seed-only query "
-            f"with empty company_name. Calls: {scout._ct.search_by_org.mock_calls}"  # type: ignore[attr-defined]
+        # cast() tells mypy the source-level mock replacement made this an
+        # AsyncMock at runtime (not the original Coroutine method).
+        search_by_org = cast("AsyncMock", scout._ct.search_by_org)
+        assert search_by_org.mock_calls == [], (
+            f"search_by_org was called {len(search_by_org.mock_calls)} times on "
+            f"seed-only query with empty company_name. Calls: {search_by_org.mock_calls}"
         )
 
     @pytest.mark.asyncio

--- a/domain_scout/tests/test_acceptance.py
+++ b/domain_scout/tests/test_acceptance.py
@@ -213,3 +213,52 @@ class TestWalmartAcceptance:
                 f"{key_domain} missing rdap_registrant_match, "
                 f"sources={domain_map[key_domain].sources}"
             )
+
+
+class TestSeedOnlyDiscovery:
+    """Reverse-lookup flow: seed_domain only, no company_name.
+
+    Guards the seed-only path against firing empty-name CT/GLEIF/subsidiary
+    queries that would either hit a real upstream with an empty search
+    term or return junk results. Each strategy that needs a company name
+    should be skipped via `if entity.company_name` in scout._discover.
+    """
+
+    @pytest.mark.asyncio
+    async def test_seed_only_skips_org_search(self) -> None:
+        """Strategy A (CT org search) must NOT fire when company_name is empty."""
+        scout = _make_scout()
+        entity = EntityInput(seed_domain=["walmart.com"])
+        await scout.discover_async(entity)
+
+        # search_by_org should never have been called — Strategy A is gated
+        # on `entity.company_name`. search_by_domain is still expected to fire.
+        org_calls = [
+            call
+            for call in scout._ct.search_by_org.mock_calls
+            if call.kwargs.get("verify_org") is not False  # type: ignore[attr-defined]
+        ]
+        assert len(org_calls) == 0, (
+            f"search_by_org was called {len(org_calls)} times on seed-only query "
+            f"with empty company_name. Calls: {scout._ct.search_by_org.mock_calls}"  # type: ignore[attr-defined]
+        )
+
+    @pytest.mark.asyncio
+    async def test_seed_only_returns_domains(self) -> None:
+        """Seed-only query still returns the seed domain itself, attributed via cert org."""
+        scout = _make_scout()
+        entity = EntityInput(seed_domain=["walmart.com"])
+        result = await scout.discover_async(entity)
+
+        found = {d.domain for d in result.domains}
+        assert "walmart.com" in found, f"Seed domain missing from results: {found}"
+
+    @pytest.mark.asyncio
+    async def test_seed_only_no_company_name_in_metadata(self) -> None:
+        """The empty company_name surfaces as-is in the result entity."""
+        scout = _make_scout()
+        entity = EntityInput(seed_domain=["walmart.com"])
+        result = await scout.discover_async(entity)
+
+        assert result.entity.company_name == ""
+        assert result.entity.seed_domain == ["walmart.com"]

--- a/domain_scout/tests/test_acceptance.py
+++ b/domain_scout/tests/test_acceptance.py
@@ -217,13 +217,7 @@ class TestWalmartAcceptance:
 
 
 class TestSeedOnlyDiscovery:
-    """Reverse-lookup flow: seed_domain only, no company_name.
-
-    Guards the seed-only path against firing empty-name CT/GLEIF/subsidiary
-    queries that would either hit a real upstream with an empty search
-    term or return junk results. Each strategy that needs a company name
-    should be skipped via `if entity.company_name` in scout._discover.
-    """
+    """Reverse-lookup flow: seed_domain only, no company_name."""
 
     @pytest.mark.asyncio
     async def test_seed_only_skips_org_search(self) -> None:

--- a/domain_scout/tests/test_models.py
+++ b/domain_scout/tests/test_models.py
@@ -22,3 +22,53 @@ def test_entity_input_seed_domain_max_length() -> None:
         )
 
     assert "List should have at most 50 items after validation" in str(exc_info.value)
+
+
+def test_entity_input_company_name_only() -> None:
+    """Forward discovery: company_name without seed_domain is valid."""
+    entity = EntityInput(company_name="Coalition Inc")
+    assert entity.company_name == "Coalition Inc"
+    assert entity.seed_domain == []
+
+
+def test_entity_input_seed_domain_only() -> None:
+    """Reverse lookup: seed_domain without company_name is valid.
+
+    Previously rejected by ``min_length=1`` on company_name. Now accepted
+    so that 'what org owns this domain?' queries don't need a brand-name
+    hint up front.
+    """
+    entity = EntityInput(seed_domain=["coalition.com"])
+    assert entity.company_name == ""
+    assert entity.seed_domain == ["coalition.com"]
+
+
+def test_entity_input_both_fields_valid() -> None:
+    """Both fields provided is also valid — scout uses both signals."""
+    entity = EntityInput(
+        company_name="Coalition Inc",
+        seed_domain=["coalition.com", "coalitioninc.com"],
+    )
+    assert entity.company_name == "Coalition Inc"
+    assert len(entity.seed_domain) == 2
+
+
+def test_entity_input_neither_field_rejected() -> None:
+    """Empty company_name AND empty seed_domain is the misuse case."""
+    with pytest.raises(ValidationError) as exc_info:
+        EntityInput()
+    assert "either company_name or seed_domain is required" in str(exc_info.value)
+
+
+def test_entity_input_empty_string_and_empty_list_rejected() -> None:
+    """Explicit empty values for both fields hit the same validator."""
+    with pytest.raises(ValidationError) as exc_info:
+        EntityInput(company_name="", seed_domain=[])
+    assert "either company_name or seed_domain is required" in str(exc_info.value)
+
+
+def test_entity_input_company_name_max_length_still_enforced() -> None:
+    """The 200-char cap on company_name is still active."""
+    with pytest.raises(ValidationError) as exc_info:
+        EntityInput(company_name="x" * 201)
+    assert "at most 200" in str(exc_info.value)

--- a/domain_scout/tests/test_models.py
+++ b/domain_scout/tests/test_models.py
@@ -32,12 +32,7 @@ def test_entity_input_company_name_only() -> None:
 
 
 def test_entity_input_seed_domain_only() -> None:
-    """Reverse lookup: seed_domain without company_name is valid.
-
-    Previously rejected by ``min_length=1`` on company_name. Now accepted
-    so that 'what org owns this domain?' queries don't need a brand-name
-    hint up front.
-    """
+    """seed_domain alone is valid (reverse-lookup flow)."""
     entity = EntityInput(seed_domain=["coalition.com"])
     assert entity.company_name == ""
     assert entity.seed_domain == ["coalition.com"]

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "domain-scout-ct"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "dnspython" },


### PR DESCRIPTION
## Problem

`EntityInput.company_name` was declared as `Field(min_length=1, max_length=200)` — required AND non-empty. This forces every caller to provide a company name even when they have the exact apex domain they want to reverse-lookup.

Hit downstream as a 422 against the Spark origin (`origin.ctscout.dev`) when the hosted MCP's `ctscout_lookup_domain` tool sent `seed_domain` only:

```
422 {"detail":[{"type":"missing","loc":["body","company_name"],
     "msg":"Field required",
     "input":{"seed_domain":["travelers.com","thehartford.com"]}}]}
```

Reverse-lookup ("what org owns this domain?") is a legitimate use case: Scout's domain-side signals (cert subject org extraction, RDAP registrant lookup, DNS resolution, fingerprint matching) attribute the org without needing a brand-name hint up front. The `min_length=1` was an over-tight constraint on a model designed to support both forward (org → domains) and reverse (domain → org) flows.

## Fix

```diff
-    company_name: str = Field(min_length=1, max_length=200)
+    company_name: str = Field(default="", max_length=200)
+
+    @model_validator(mode="after")
+    def _require_at_least_one_input(self) -> Self:
+        if not self.company_name and not self.seed_domain:
+            raise ValueError("either company_name or seed_domain is required")
+        return self
```

The validator catches the new edge case — `EntityInput()` with neither field provided would previously have failed via `min_length=1`; now it fails with a clearer "either/or" message.

**Why keep `str` (not `str | None`)** — scout.py uses `entity.company_name` in ~12 call sites (org-search strategy, domain guessing, GLEIF subsidiary expansion, RDAP corroboration). All of them already short-circuit on falsy values via `if name:` checks. Empty string preserves that behavior without requiring a refactor.

## Verification

Manual verification + reproduction in the test fixtures:

- [x] 6 new `EntityInput` tests in `test_models.py`:
  - `test_entity_input_company_name_only` — forward discovery still works
  - `test_entity_input_seed_domain_only` — **reverse lookup now works** (was the bug)
  - `test_entity_input_both_fields_valid` — combined queries unchanged
  - `test_entity_input_neither_field_rejected` — empty `EntityInput()` raises with clear message
  - `test_entity_input_empty_string_and_empty_list_rejected` — explicit empties same path
  - `test_entity_input_company_name_max_length_still_enforced` — 200-char cap preserved
- [x] `make test`: 624/624 existing unit tests pass — no regressions in scout/cli/api/delta/eval/etc.
- [x] `ruff check`, `ruff format --check`: clean
- [x] `mypy --strict domain_scout/models.py`: clean
- [ ] Post-merge: redeploy DGX origin (`cd ~/domain-scout && git pull && systemctl --user restart domain-scout-api.service`), then re-run the failing `tools/call ctscout_lookup_domain` curl against ctscout.dev — expect 200 with a real markdown table

## Downstream impact

- `domain_scout/api.py` accepts the looser model transparently (no code change there).
- `domain-scout-api` (the DGX wrapper) consumes `domain_scout.models.EntityInput` via editable install — picks up the change automatically on the next `git pull && systemctl restart`. No version bump needed.
- `domain-scout/scout.py` internals tested via existing scout/subsidiary/fingerprint suites that I did NOT modify — 624/624 confirms empty-string `entity.company_name` flows through correctly.

## Test plan

- [x] New unit tests pass
- [x] Full unit suite passes (624 tests)
- [x] Lint, format, mypy clean
- [x] Pre-fix evidence captured (the 422 from the reproduction curl)
- [x] Post-fix evidence captured (the new tests, which would fail against the pre-fix model)
- [ ] Post-DGX-redeploy: end-to-end `tools/call ctscout_lookup_domain` returns 200