### PR TITLE
🧹 [Remove unused annotations import in eval.py]

### DIFF
--- a/domain_scout/eval.py
+++ b/domain_scout/eval.py
@@ -9,8 +9,6 @@ Usage:
   python -m domain_scout.eval --mode live --output json
 """
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import math


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` import from `domain_scout/eval.py` at line 12.
💡 **Why:** This improves maintainability and readability by keeping the imports clean and addressing code health issues reported by linters or manual analysis.
✅ **Verification:** Verified by running `uv run ruff format .` and `uv run ruff check --fix .`. Ran the full test suite (`uv run --all-extras pytest`) and specifically `domain_scout/tests/test_eval.py` to ensure no functionality is broken.
✨ **Result:** The code health issue is resolved, code is cleaner, and functionality remains intact.

---
*PR created automatically by Jules for task [3967481206699366811](https://jules.google.com/task/3967481206699366811) started by @minghsuy*