### PR TITLE
🧹 [Optimize URL extraction to reduce allocations]

### DIFF
--- a/domain_scout/resolve/gleif_ingest.py
+++ b/domain_scout/resolve/gleif_ingest.py
@@ -38,7 +38,7 @@ def _get_download_urls() -> tuple[str, str]:
 
 def _download_and_extract(url: str, dest_dir: Path) -> Path:
     """Download a zip file and extract the CSV inside it."""
-    log.info("gleif.downloading", url=url.split("/")[-1])
+    log.info("gleif.downloading", url=url.rsplit("/", maxsplit=1)[-1])
     resp = httpx.get(url, timeout=300, follow_redirects=True)
     resp.raise_for_status()
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced `url.split("/")[-1]` with `url.rsplit("/", maxsplit=1)[-1]` on line 41 of `domain_scout/resolve/gleif_ingest.py`.

💡 **Why:** How this improves maintainability
Using `split("/")[-1]` splits the entire URL string into a full list of all its path segments just to get the final segment. By using `rsplit("/", maxsplit=1)[-1]`, we start splitting from the right and stop after a single split, significantly reducing the number of unnecessary intermediate string and list allocations, which is especially useful for longer URLs. This is a common Python optimization pattern for filename extraction.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run ruff format .`, `uv run ruff check --fix .`, and `uv run --all-extras pytest`. All formatters, linters, and the full test suite passed successfully without regression. The logic is functionally identical since we are still extracting the last component of the URL.

✨ **Result:** The improvement achieved
Reduced memory allocation overhead when parsing download URLs in `gleif_ingest.py`, resulting in cleaner, more efficient code with no change to the underlying business logic.

---
*PR created automatically by Jules for task [876760574871016872](https://jules.google.com/task/876760574871016872) started by @minghsuy*