### PR TITLE
🧹 [Simplify return by removing unnecessary assignment in gleif_lookup]

### DIFF
--- a/domain_scout/resolve/gleif_lookup.py
+++ b/domain_scout/resolve/gleif_lookup.py
@@ -251,8 +251,7 @@ def _normalize_for_gleif(name: str) -> str:
         n = stripped
     # Collapse whitespace, strip punctuation edges
     n = re.sub(r"[,.]", "", n)
-    n = " ".join(n.split()).strip()
-    return n
+    return " ".join(n.split()).strip()
 
 
 def _row_to_entity(row: tuple[Any, ...]) -> GleifEntity:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unnecessary assignment `n = " ".join(n.split()).strip()` followed by `return n` in `_normalize_for_gleif` within `domain_scout/resolve/gleif_lookup.py`.

💡 **Why:** How this improves maintainability
Returning the value directly simplifies the function, reducing boilerplate and improving readability without changing functionality.

✅ **Verification:** How you confirmed the change is safe
Ran formatters (`uv run ruff format .`), linters (`uv run ruff check --fix .`), and the full test suite (`uv run --all-extras pytest`). All checks passed and the refactoring is functionally equivalent.

✨ **Result:** The improvement achieved
Cleaner, more concise code in `gleif_lookup.py`.

---
*PR created automatically by Jules for task [12393937241104519179](https://jules.google.com/task/12393937241104519179) started by @minghsuy*