### PR TITLE
🧹 [code health: remove unused future annotations in config]

### DIFF
--- a/domain_scout/config.py
+++ b/domain_scout/config.py
@@ -1,7 +1,5 @@
 """Configuration constants and defaults."""
 
-from __future__ import annotations
-
 import dataclasses
 from dataclasses import dataclass, field
 from typing import Literal
@@ -122,7 +120,7 @@ class ScoutConfig:
         return dataclasses.asdict(self)
 
     @classmethod
-    def from_profile(cls, profile: ProfileName, **overrides: object) -> ScoutConfig:
+    def from_profile(cls, profile: ProfileName, **overrides: object) -> "ScoutConfig":
         """Create a config from a named profile with optional overrides."""
         if profile not in _PROFILES:
             raise ValueError(f"Unknown profile: {profile!r}. Choose from: {', '.join(_PROFILES)}")


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `domain_scout/config.py` and wrapped the self-referential `ScoutConfig` return type hint in quotes to prevent a forward reference error.
💡 **Why:** To improve code health by removing unnecessary imports, cleaning up the file header while preserving type safety.
✅ **Verification:** Verified that `ruff`, `mypy`, and the `pytest` test suite run cleanly and functionally without errors.
✨ **Result:** A cleaner `config.py` file without affecting behavior.

---
*PR created automatically by Jules for task [9602813023215875474](https://jules.google.com/task/9602813023215875474) started by @minghsuy*