### PR TITLE
🧹 [Remove unused annotations import]

### DIFF
--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -1,7 +1,5 @@
 """Pydantic models for input, output, and intermediate data."""
 
-from __future__ import annotations
-
 from datetime import datetime  # noqa: TC003 — Pydantic needs runtime import
 from typing import Self
 


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` in `domain_scout/models.py`.
💡 **Why:** Clean up unused code and imports for better readability and maintainability. Given the python version requirement `requires-python = ">=3.12"`, modern typing supports like `typing.Self` or pipe union `|` are built-in and don't necessitate delayed evaluation via this `__future__` import.
✅ **Verification:** Ran `uv run ruff check --fix .`, `uv run ruff format .` and `uv run pytest domain_scout/tests/test_models.py` along with all tests `uv run --all-extras pytest`. The code successfully linted, formatted and all tests passed smoothly.
✨ **Result:** Improved code cleanliness by discarding unused legacy import constructs while keeping logic intact.

---
*PR created automatically by Jules for task [8706937570250370562](https://jules.google.com/task/8706937570250370562) started by @minghsuy*