### PR TITLE
🧹 [Code Health] Use maxsplit in string split to reduce allocations

### DIFF
--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -75,7 +75,7 @@ _ORG_MATCH_TAGS = frozenset({"ct_org_match", "ct_subsidiary_match", "ct_gleif_su
 
 def _signal_fields(source_tag: str) -> dict[str, Any]:
     """Return signal_type and signal_weight for a source tag."""
-    sig = _SIGNAL_MAP.get(source_tag.split(":")[0])
+    sig = _SIGNAL_MAP.get(source_tag.split(":", 1)[0])
     if sig is None:
         return {}
     return {"signal_type": sig[0], "signal_weight": sig[1]}
@@ -777,7 +777,7 @@ class Scout:
         seed_slug = extract_base_domain(seed)
         if seed_slug:
             # e.g., "paloaltonetworks" from "paloaltonetworks.com" vs "Palo Alto Networks"
-            slug_part = seed_slug.split(".")[0]
+            slug_part = seed_slug.split(".", 1)[0]
             slug_score = org_name_similarity(slug_part, company_name)
             if slug_score > best_score:
                 best_score = slug_score


### PR DESCRIPTION
🎯 **What:**
Updated `domain_scout/scout.py` to use `maxsplit=1` in `split()` calls when only the first part `[0]` is needed.

💡 **Why:**
Without `maxsplit`, the `split()` function processes the entire string and allocates a full list of all segments, only for all segments past index 0 to be discarded. Using `maxsplit=1` limits the parsing and allocation to just two parts, improving efficiency and reducing unnecessary object creation, particularly on long or complex strings like source tags and domains.

✅ **Verification:**
* Ran unit test suite with all extras enabled using `pytest`. All passed.
* Ran static analysis, type checking, and format checks (`ruff` and `mypy`).

✨ **Result:**
Reduced string parsing overhead in tight orchestrator loops while preserving identical functionality.

---
*PR created automatically by Jules for task [16599177296884278763](https://jules.google.com/task/16599177296884278763) started by @minghsuy*