### PR TITLE
🧹 Fix excessive string splits in scorer logic

### DIFF
--- a/domain_scout/scorer/__init__.py
+++ b/domain_scout/scorer/__init__.py
@@ -91,7 +91,7 @@ def _tld_is_country(domain: str) -> int:
 
 
 def _domain_has_company_token(domain: str, company_name: str) -> int:
-    base = domain.split(".")[0].lower()
+    base = domain.split(".", maxsplit=1)[0].lower()
     tokens = [t.lower().rstrip(".,") for t in company_name.split() if len(t) >= 3]
     tokens = [t for t in tokens if t not in _COMPANY_SUFFIX_SKIP]
     return 1 if any(t in base for t in tokens) else 0
@@ -171,7 +171,7 @@ def score_confidence(
         "org_matches_different_entity": 0.0,  # requires S&P 500 data, not available at inference
         "evidence_density": evidence_density,
         "resolves": float(resolves),
-        "domain_length": float(len(domain.split(".")[0])),
+        "domain_length": float(len(domain.split(".", maxsplit=1)[0])),
         "rdap_similarity": rdap_similarity,
         # ASN/NS features: not available at inference (would need separate DNS+ASN lookup)
         "same_asn_as_anchor": 0.0,


### PR DESCRIPTION
**🎯 What:** Added `maxsplit=1` to `domain.split(".")` when extracting the base domain segment and domain length.
**💡 Why:** This prevents unnecessary list allocations and wasted CPU cycles when splitting domain strings that contain multiple dots, slightly improving performance since we only ever need the first segment.
**✅ Verification:** Ran `ruff format .`, `ruff check --fix .`, and `uv run --all-extras pytest`. All pass perfectly.
**✨ Result:** Extraneous array building is avoided, improving the computational efficiency of scoring features.

---
*PR created automatically by Jules for task [16515705744688808843](https://jules.google.com/task/16515705744688808843) started by @minghsuy*