### PR TITLE
🧹 [Use maxsplit=1 in domain.split() for memory efficiency]

### DIFF
--- a/domain_scout/scorer/__init__.py
+++ b/domain_scout/scorer/__init__.py
@@ -91,7 +91,7 @@ def _tld_is_country(domain: str) -> int:
 
 
 def _domain_has_company_token(domain: str, company_name: str) -> int:
-    base = domain.split(".")[0].lower()
+    base = domain.split(".", maxsplit=1)[0].lower()
     tokens = [t.lower().rstrip(".,") for t in company_name.split() if len(t) >= 3]
     tokens = [t for t in tokens if t not in _COMPANY_SUFFIX_SKIP]
     return 1 if any(t in base for t in tokens) else 0
@@ -171,7 +171,7 @@ def score_confidence(
         "org_matches_different_entity": 0.0,  # requires S&P 500 data, not available at inference
         "evidence_density": evidence_density,
         "resolves": float(resolves),
-        "domain_length": float(len(domain.split(".")[0])),
+        "domain_length": float(len(domain.split(".", maxsplit=1)[0])),
         "rdap_similarity": rdap_similarity,
         # ASN/NS features: not available at inference (would need separate DNS+ASN lookup)
         "same_asn_as_anchor": 0.0,


### PR DESCRIPTION
🎯 **What:** Modified string `split()` calls in `domain_scout/scorer/__init__.py` to use `maxsplit=1` when only the first element `[0]` is accessed.
💡 **Why:** Using an unbounded `split()` allocates a full list of all domain parts, which is unnecessary when we only need the base segment before the first period. Using `maxsplit=1` reduces memory allocations and improves performance for string processing loops.
✅ **Verification:** Validated that tests still pass with `uv run --all-extras pytest domain_scout/tests/test_scorer.py` and `uv run --all-extras pytest`. Formatted and type-checked via `uv run ruff format .` and `uv run ruff check --fix .`.
✨ **Result:** A safer, more memory-efficient string parsing pattern in the scorer module without behavior changes.

---
*PR created automatically by Jules for task [11897646277929164951](https://jules.google.com/task/11897646277929164951) started by @minghsuy*