### PR TITLE
🧹 [code health improvement] Remove unused annotations import in domain_scout/cache.py

### DIFF
--- a/domain_scout/cache.py
+++ b/domain_scout/cache.py
@@ -1,7 +1,5 @@
 """DuckDB-based query cache for CT and RDAP results."""
 
-from __future__ import annotations
-
 import asyncio
 import hashlib
 import json
@@ -64,7 +62,7 @@ class DuckDBCache:
         self._init_tables()
         log.debug("cache.opened", path=str(db_path))
 
-    def __enter__(self) -> DuckDBCache:
+    def __enter__(self) -> "DuckDBCache":
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -220,7 +218,7 @@ class RDAPSource(Protocol):
 class CachedCTLogSource:
     """Transparent caching wrapper around CTLogSource."""
 
-    def __init__(self, inner: CTLogSource, cache: DuckDBCache) -> None:
+    def __init__(self, inner: "CTLogSource", cache: "DuckDBCache") -> None:
         self._inner = inner
         self._cache = cache
 
@@ -260,7 +258,7 @@ class CachedCTLogSource:
 class CachedRDAPLookup:
     """Transparent caching wrapper around RDAPLookup."""
 
-    def __init__(self, inner: RDAPLookup, cache: DuckDBCache) -> None:
+    def __init__(self, inner: "RDAPLookup", cache: "DuckDBCache") -> None:
         self._inner = inner
         self._cache = cache
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `domain_scout/cache.py` and updated dependent type hints (`CTLogSource`, `RDAPLookup`, and `DuckDBCache`) to use string literals to avoid runtime `NameError`s.

💡 **Why:** Removing unnecessary imports improves code maintainability and reduces clutter. Since `from __future__ import annotations` disables eager type hint evaluation, removing it required updating type hints referring to classes in `if TYPE_CHECKING:` blocks to use string literals for forward references to ensure standard Python execution behavior without errors.

✅ **Verification:** Verified by checking type linting with `ruff` and `mypy` natively. Missing testing dependencies were installed and the entire `pytest` test suite was run without error.

✨ **Result:** Cleaner code in `domain_scout/cache.py` matching standard runtime type hint behavior and ensuring compatibility with tools without breaking the runtime logic.

---
*PR created automatically by Jules for task [539880539127659656](https://jules.google.com/task/539880539127659656) started by @minghsuy*