### PR TITLE
🧹 [code health] Remove unused annotations import in logging

### DIFF
--- a/domain_scout/_logging.py
+++ b/domain_scout/_logging.py
@@ -1,7 +1,5 @@
 """Shared logging configuration for domain-scout."""
 
-from __future__ import annotations
-
 import logging
 import sys
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `domain_scout/_logging.py`.
💡 **Why:** This resolves a minor code health issue and cleans up the imports, improving readability and adhering to cleaner code standards. Python 3.12+ (which this project uses) generally does not need this unless specifically forward referencing within string literals or similar cases, but here it was completely unused.
✅ **Verification:** Ran `uv run ruff check`, `uv run ruff format --check`, and the full test suite (`uv run --all-extras pytest domain_scout/tests`), which all passed successfully, ensuring the change is safe.
✨ **Result:** A cleaner `_logging.py` file with no unused imports.

---
*PR created automatically by Jules for task [4197621950026401644](https://jules.google.com/task/4197621950026401644) started by @minghsuy*