### PR TITLE
🧪 [test FastAPI lifespan context manager]

### DIFF
--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -515,8 +515,7 @@ class TestAppLifespan:
     def test_lifespan_closes_cache(self) -> None:
         """App lifespan closes cache on shutdown."""
         mock_cache = MagicMock()
-        app = create_app()
-        app.state.cache = mock_cache
+        app = create_app(cache=mock_cache)
         with TestClient(app):
             pass
         mock_cache.close.assert_called_once()
@@ -524,6 +523,5 @@ class TestAppLifespan:
     def test_lifespan_no_cache(self) -> None:
         """App lifespan handles absent cache smoothly."""
         app = create_app()
-        app.state.cache = None
         with TestClient(app):
             pass

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -509,3 +509,21 @@ class TestAPIKeyAuth:
             headers={"Authorization": "Bearer secret-key"},
         )
         assert resp.status_code == 200
+
+
+class TestAppLifespan:
+    def test_lifespan_closes_cache(self) -> None:
+        """App lifespan closes cache on shutdown."""
+        mock_cache = MagicMock()
+        app = create_app()
+        app.state.cache = mock_cache
+        with TestClient(app):
+            pass
+        mock_cache.close.assert_called_once()
+
+    def test_lifespan_no_cache(self) -> None:
+        """App lifespan handles absent cache smoothly."""
+        app = create_app()
+        app.state.cache = None
+        with TestClient(app):
+            pass


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The FastAPI `create_app` factory in `domain_scout/api.py` includes a `lifespan` context manager that handles closing the cache on shutdown. This functionality was missing explicit test coverage.

📊 **Coverage:** What scenarios are now tested
Added `TestAppLifespan` to `domain_scout/tests/test_api.py` to cover:
- Happy path: A mock cache is passed to `create_app`, and the test ensures `mock_cache.close()` is called exactly once when the application shuts down.
- Null case: Testing that the lifespan correctly skips cache closure and handles the `cache=None` case without throwing errors.

✨ **Result:** The improvement in test coverage
The lifespan startup and shutdown routines are now explicitly verified, ensuring resources are properly cleaned up upon termination. This test improvement prevents regressions to the application lifecycle logic.

---
*PR created automatically by Jules for task [6249502131882667322](https://jules.google.com/task/6249502131882667322) started by @minghsuy*