### PR TITLE
🧹 [remove unused annotations import in cli]

### DIFF
--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -1,7 +1,5 @@
 """CLI interface for domain-scout."""
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path  # noqa: TC003 — Typer needs runtime import
 from typing import TYPE_CHECKING, Annotated
@@ -254,7 +252,7 @@ def diff(
         _print_delta_table(report)
 
 
-def _get_cache_or_exit(cache_dir: str | Path | None = None) -> DuckDBCache:
+def _get_cache_or_exit(cache_dir: str | Path | None = None) -> "DuckDBCache":
     """Import and instantiate DuckDBCache, or exit with a friendly error."""
     try:
         from domain_scout.cache import DuckDBCache
@@ -268,7 +266,7 @@ def _get_cache_or_exit(cache_dir: str | Path | None = None) -> DuckDBCache:
         raise typer.Exit(1) from None
 
 
-def _load_result(path: Path, label: str) -> ScoutResult:
+def _load_result(path: Path, label: str) -> "ScoutResult":
     """Load and validate a ScoutResult JSON file, or exit with an error."""
     from domain_scout.models import ScoutResult
 
@@ -287,7 +285,7 @@ def _load_result(path: Path, label: str) -> ScoutResult:
         raise typer.Exit(1) from None
 
 
-def _print_delta_table(report: DeltaReport) -> None:
+def _print_delta_table(report: "DeltaReport") -> None:
     """Pretty-print a delta report as a table."""
     # Warnings to stderr
     for w in report.warnings:
@@ -380,7 +378,7 @@ def cache_clear(
     typer.echo("  Cache cleared.")
 
 
-def _print_table(result: ScoutResult) -> None:
+def _print_table(result: "ScoutResult") -> None:
     """Pretty-print results as a table to stderr/stdout."""
     typer.echo(f"\n  Entity: {result.entity.company_name}", err=True)
     if result.entity.location:


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `domain_scout/cli.py` and correctly stringified the forward type references inside `cli.py` functions to avoid runtime regressions like `NameError`.
💡 **Why:** By removing the unused code safely, we maintain the codebase clean without adding performance regressions. The solution handles type references gracefully.
✅ **Verification:** Ran `uv run ruff check .` and `uv run ruff format .` showing 0 errors, run `uv run --all-extras pytest domain_scout/tests/test_cli.py` directly without errors, verified codebase behavior and got Code Review Approval.
✨ **Result:** A cleaner codebase without any regressions and correctly working type annotations.

---
*PR created automatically by Jules for task [659704129184024274](https://jules.google.com/task/659704129184024274) started by @minghsuy*