### PR TITLE
🔒 fix path traversal bypass via absolute path

### DIFF
--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -43,7 +43,7 @@ _READY_CACHE_TTL = 60.0
 
 def _reject_traversal(path: str, field: str) -> None:
     """Raise 400 if path contains '..' components."""
-    if ".." in Path(path).parts:
+    if ".." in Path(path).parts or Path(path).is_absolute():
         raise HTTPException(status_code=400, detail=f"Invalid {field}: path traversal detected")
 
 
@@ -174,16 +174,18 @@ def create_app(
         local_mode = req.local_mode if req.local_mode is not None else app.state.default_local_mode
         if local_mode != "disabled":
             overrides["local_mode"] = local_mode
-            warehouse = req.warehouse_path or app.state.default_warehouse_path
-            if warehouse:
-                _reject_traversal(warehouse, "warehouse_path")
-                overrides["warehouse_path"] = warehouse
+            if req.warehouse_path:
+                _reject_traversal(req.warehouse_path, "warehouse_path")
+                overrides["warehouse_path"] = req.warehouse_path
+            elif app.state.default_warehouse_path:
+                overrides["warehouse_path"] = app.state.default_warehouse_path
 
         # Resolve subsidiaries_path: request overrides server default
-        subs = req.subsidiaries_path or app.state.default_subsidiaries_path
-        if subs:
-            _reject_traversal(subs, "subsidiaries_path")
-            overrides["subsidiaries_path"] = subs
+        if req.subsidiaries_path:
+            _reject_traversal(req.subsidiaries_path, "subsidiaries_path")
+            overrides["subsidiaries_path"] = req.subsidiaries_path
+        elif app.state.default_subsidiaries_path:
+            overrides["subsidiaries_path"] = app.state.default_subsidiaries_path
 
         try:
             if req.profile:

--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -42,9 +42,11 @@ _READY_CACHE_TTL = 60.0
 
 
 def _reject_traversal(path: str, field: str) -> None:
-    """Raise 400 if path contains '..' components."""
-    if ".." in Path(path).parts or Path(path).is_absolute():
+    """Raise 400 if path contains '..' components or is an absolute path."""
+    if ".." in Path(path).parts:
         raise HTTPException(status_code=400, detail=f"Invalid {field}: path traversal detected")
+    if Path(path).is_absolute():
+        raise HTTPException(status_code=400, detail=f"Invalid {field}: must be a relative path")
 
 
 class ScanRequest(BaseModel):

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -299,6 +299,7 @@ class TestScanRequest:
             },
         )
         assert resp_absolute.status_code == 400
+        assert "Invalid warehouse_path" in resp_absolute.json()["detail"]
 
     def test_scan_subsidiaries_path_traversal(
         self, client: TestClient, mock_discover: AsyncMock

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -314,6 +314,17 @@ class TestScanRequest:
         assert resp.status_code == 400
         assert "Invalid subsidiaries_path" in resp.json()["detail"]
 
+        # Absolute paths must also be rejected
+        resp_absolute = client.post(
+            "/scan",
+            json={
+                "entity": {"company_name": "TestCorp"},
+                "subsidiaries_path": "/etc/passwd",
+            },
+        )
+        assert resp_absolute.status_code == 400
+        assert "Invalid subsidiaries_path" in resp_absolute.json()["detail"]
+
 
 class TestServerDefaults:
     """Tests for server-default configuration via create_app params."""

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -289,7 +289,7 @@ class TestScanRequest:
         assert resp.status_code == 400
         assert "Invalid warehouse_path" in resp.json()["detail"]
 
-        # Absolute paths must NOT be rejected as traversal
+        # Absolute paths must be rejected as traversal
         resp_absolute = client.post(
             "/scan",
             json={
@@ -298,7 +298,7 @@ class TestScanRequest:
                 "warehouse_path": "/opt/warehouse",
             },
         )
-        assert resp_absolute.status_code != 400
+        assert resp_absolute.status_code == 400
 
     def test_scan_subsidiaries_path_traversal(
         self, client: TestClient, mock_discover: AsyncMock
@@ -351,7 +351,7 @@ class TestServerDefaults:
                 json={
                     "entity": {"company_name": "TestCorp"},
                     "local_mode": "local_only",
-                    "warehouse_path": "/other/warehouse",
+                    "warehouse_path": "other/warehouse",
                 },
             )
         assert resp.status_code == 200


### PR DESCRIPTION
**🎯 What:**
Fixed a path traversal bypass vulnerability in the `_reject_traversal` function.

**⚠️ Risk:**
An attacker could bypass the `".." in Path(path).parts` check by providing an absolute path (e.g., `/etc/passwd`), potentially leading to arbitrary file read or write depending on how the path is subsequently used.

**🛡️ Solution:**
Added `or Path(path).is_absolute()` to the condition in `_reject_traversal` so that both relative traversal and absolute paths are rejected. Also updated the `/scan` endpoint to only validate user-supplied paths, preserving the ability of server administrators to use absolute paths for default configurations. Updated test cases to reflect these changes.

---
*PR created automatically by Jules for task [9296849994483437160](https://jules.google.com/task/9296849994483437160) started by @minghsuy*