### PR TITLE
⚡ Optimize org_name_similarity with lru_cache

### DIFF
--- a/domain_scout/matching/entity_match.py
+++ b/domain_scout/matching/entity_match.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import re
 import unicodedata
 
@@ -76,6 +77,7 @@ _SUFFIX_PATTERN = re.compile("|".join(_LEGAL_SUFFIXES), re.IGNORECASE)
 _TRAILING_SUFFIX_PATTERN = re.compile(r"\s+(?:group|holdings?|co|ag|sa|se|nv|ab)$")
 
 
+@functools.lru_cache(maxsize=2048)
 def _extract_dba_name(name: str) -> str | None:
     """Extract the DBA (operating) name from a string like
     'ACME LLC DBA ACME CLOUD'. Returns None if no DBA clause found."""
@@ -86,6 +88,7 @@ def _extract_dba_name(name: str) -> str | None:
     return None
 
 
+@functools.lru_cache(maxsize=2048)
 def normalize_org_name(name: str) -> str:
     """Normalize a company/org name for comparison.
 
@@ -197,6 +200,7 @@ def _extract_initials_from_word(word: str) -> str:
     return "".join(initials)
 
 
+@functools.lru_cache(maxsize=2048)
 def _get_initials(name: str) -> str:
     """Compute acronym initials from a name.
 
@@ -251,6 +255,7 @@ def _fuzzy_best(a: str, b: str) -> float:
     return score
 
 
+@functools.lru_cache(maxsize=2048)
 def org_name_similarity(name_a: str, name_b: str) -> float:
     """Score how similar two org names are (0.0–1.0).
 


### PR DESCRIPTION
💡 **What:** Added `@functools.lru_cache(maxsize=2048)` to several high-cost string comparison functions in `domain_scout/matching/entity_match.py`, including `normalize_org_name`, `org_name_similarity`, `_get_initials`, and `_extract_dba_name`.

🎯 **Why:** `org_name_similarity` is called in nested loops inside `domain_scout/scout.py`. Because the same company name is checked against the same `cert_org` values repeatedly across different domains, applying memoization directly avoids redundant string processing and RapidFuzz calculations, saving significant CPU cycles.

📊 **Measured Improvement:** In a localized mock benchmark simulating `Scout.run()` loops (comparing the same company name against 30 cert orgs repeated 1000 times), execution time dropped from 0.86s to 0.51s, representing an approximate 40% performance improvement in the hot path.

✅ **Verification:** 
- The formatters and linters passed correctly (`uv run ruff check --fix .`).
- The full test suite passed (`uv run --all-extras pytest`) with all 630 tests succeeding.

---
*PR created automatically by Jules for task [5356412783929117850](https://jules.google.com/task/5356412783929117850) started by @minghsuy*