### PR TITLE
🧹 [metrics] Remove unused `__future__` import

### DIFF
--- a/domain_scout/_metrics.py
+++ b/domain_scout/_metrics.py
@@ -82,8 +82,7 @@ def generate_latest() -> bytes:
     """Return Prometheus metrics in text exposition format. Empty bytes if disabled."""
     if not _ENABLED:
         return b""  # pragma: no cover
-    res: bytes = _generate_latest()
-    return res
+    return _generate_latest()
 
 
 def inc(counter: Any, amount: float = 1, **labels: str) -> None:

--- a/domain_scout/_metrics.py
+++ b/domain_scout/_metrics.py
@@ -1,8 +1,6 @@
 """Prometheus metrics for domain-scout. No-ops when prometheus-client is not installed."""
 
-from __future__ import annotations
-
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "CONTENT_TYPE_LATEST",
@@ -20,6 +18,9 @@ __all__ = [
     "set_gauge",
 ]
 
+if TYPE_CHECKING:
+    from prometheus_client import Counter, Gauge, Histogram
+
 try:
     from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST
     from prometheus_client import Counter, Gauge, Histogram
@@ -31,13 +32,13 @@ except ImportError:  # pragma: no cover
 
 CONTENT_TYPE_LATEST: str = _CONTENT_TYPE_LATEST if _ENABLED else ""
 
-SCANS_TOTAL: Counter | None = None
-SCAN_DURATION_SECONDS: Histogram | None = None
-DOMAINS_FOUND: Histogram | None = None
-CT_QUERIES_TOTAL: Counter | None = None
-CT_FALLBACKS_TOTAL: Counter | None = None
-CT_CIRCUIT_BREAKER_STATE: Gauge | None = None
-SOURCE_ERRORS_TOTAL: Counter | None = None
+SCANS_TOTAL: "Counter | None" = None
+SCAN_DURATION_SECONDS: "Histogram | None" = None
+DOMAINS_FOUND: "Histogram | None" = None
+CT_QUERIES_TOTAL: "Counter | None" = None
+CT_FALLBACKS_TOTAL: "Counter | None" = None
+CT_CIRCUIT_BREAKER_STATE: "Gauge | None" = None
+SOURCE_ERRORS_TOTAL: "Counter | None" = None
 
 if _ENABLED:
     SCANS_TOTAL = Counter(
@@ -81,7 +82,8 @@ def generate_latest() -> bytes:
     """Return Prometheus metrics in text exposition format. Empty bytes if disabled."""
     if not _ENABLED:
         return b""  # pragma: no cover
-    return _generate_latest()
+    res: bytes = _generate_latest()
+    return res
 
 
 def inc(counter: Any, amount: float = 1, **labels: str) -> None:


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` in `domain_scout/_metrics.py` and wrapped typing annotations in string quotes for optional Prometheus classes to prevent `NameError` at runtime while maintaining static analysis safety via `TYPE_CHECKING`.

💡 **Why:** `__future__` imports are no longer needed on Python 3.12, but removing them forced us to update how `prometheus-client`'s optional dependencies (`Counter`, `Gauge`, `Histogram`) were type-hinted so they don't break when evaluated at runtime when the package isn't installed. Using `TYPE_CHECKING` with quoted string types keeps the codebase clean and safe.

✅ **Verification:** Verified by running all unit tests in `domain_scout/tests/test_metrics.py` and running formatting, static analysis, and type checking (`ruff format`, `ruff check`, and `mypy`), all of which pass cleanly.

✨ **Result:** A safer, cleaner metric file which maintains correct typing statically without imposing runtime evaluation constraints or relying on the legacy `__future__` flag.

---
*PR created automatically by Jules for task [14680437808033649756](https://jules.google.com/task/14680437808033649756) started by @minghsuy*