### PR TITLE
Enforce future-annotations + perf/security lint to stop recurring churn

### DIFF
--- a/domain_scout/__init__.py
+++ b/domain_scout/__init__.py
@@ -1,5 +1,7 @@
 """domain-scout: Discover internet domains associated with a business entity."""
 
+from __future__ import annotations
+
 from importlib.metadata import version as _pkg_version
 
 from domain_scout._logging import configure_logging

--- a/domain_scout/_logging.py
+++ b/domain_scout/_logging.py
@@ -1,5 +1,7 @@
 """Shared logging configuration for domain-scout."""
 
+from __future__ import annotations
+
 import logging
 import sys
 

--- a/domain_scout/_metrics.py
+++ b/domain_scout/_metrics.py
@@ -1,5 +1,7 @@
 """Prometheus metrics for domain-scout. No-ops when prometheus-client is not installed."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 __all__ = [
@@ -32,13 +34,13 @@ except ImportError:  # pragma: no cover
 
 CONTENT_TYPE_LATEST: str = _CONTENT_TYPE_LATEST if _ENABLED else ""
 
-SCANS_TOTAL: "Counter | None" = None
-SCAN_DURATION_SECONDS: "Histogram | None" = None
-DOMAINS_FOUND: "Histogram | None" = None
-CT_QUERIES_TOTAL: "Counter | None" = None
-CT_FALLBACKS_TOTAL: "Counter | None" = None
-CT_CIRCUIT_BREAKER_STATE: "Gauge | None" = None
-SOURCE_ERRORS_TOTAL: "Counter | None" = None
+SCANS_TOTAL: Counter | None = None
+SCAN_DURATION_SECONDS: Histogram | None = None
+DOMAINS_FOUND: Histogram | None = None
+CT_QUERIES_TOTAL: Counter | None = None
+CT_FALLBACKS_TOTAL: Counter | None = None
+CT_CIRCUIT_BREAKER_STATE: Gauge | None = None
+SOURCE_ERRORS_TOTAL: Counter | None = None
 
 if _ENABLED:
     SCANS_TOTAL = Counter(

--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -1,14 +1,18 @@
 """FastAPI REST API for domain-scout."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import secrets
 import time
-from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
-from typing import Any, cast, get_args
+from typing import TYPE_CHECKING, Any, cast, get_args
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
 import httpx
 import structlog

--- a/domain_scout/cache.py
+++ b/domain_scout/cache.py
@@ -1,5 +1,7 @@
 """DuckDB-based query cache for CT and RDAP results."""
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json
@@ -62,7 +64,7 @@ class DuckDBCache:
         self._init_tables()
         log.debug("cache.opened", path=str(db_path))
 
-    def __enter__(self) -> "DuckDBCache":
+    def __enter__(self) -> DuckDBCache:
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -218,7 +220,7 @@ class RDAPSource(Protocol):
 class CachedCTLogSource:
     """Transparent caching wrapper around CTLogSource."""
 
-    def __init__(self, inner: "CTLogSource", cache: "DuckDBCache") -> None:
+    def __init__(self, inner: CTLogSource, cache: DuckDBCache) -> None:
         self._inner = inner
         self._cache = cache
 
@@ -258,7 +260,7 @@ class CachedCTLogSource:
 class CachedRDAPLookup:
     """Transparent caching wrapper around RDAPLookup."""
 
-    def __init__(self, inner: "RDAPLookup", cache: "DuckDBCache") -> None:
+    def __init__(self, inner: RDAPLookup, cache: DuckDBCache) -> None:
         self._inner = inner
         self._cache = cache
 

--- a/domain_scout/cli.py
+++ b/domain_scout/cli.py
@@ -1,5 +1,7 @@
 """CLI interface for domain-scout."""
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path  # noqa: TC003 — Typer needs runtime import
 from typing import TYPE_CHECKING, Annotated
@@ -252,7 +254,7 @@ def diff(
         _print_delta_table(report)
 
 
-def _get_cache_or_exit(cache_dir: str | Path | None = None) -> "DuckDBCache":
+def _get_cache_or_exit(cache_dir: str | Path | None = None) -> DuckDBCache:
     """Import and instantiate DuckDBCache, or exit with a friendly error."""
     try:
         from domain_scout.cache import DuckDBCache
@@ -266,7 +268,7 @@ def _get_cache_or_exit(cache_dir: str | Path | None = None) -> "DuckDBCache":
         raise typer.Exit(1) from None
 
 
-def _load_result(path: Path, label: str) -> "ScoutResult":
+def _load_result(path: Path, label: str) -> ScoutResult:
     """Load and validate a ScoutResult JSON file, or exit with an error."""
     from domain_scout.models import ScoutResult
 
@@ -285,7 +287,7 @@ def _load_result(path: Path, label: str) -> "ScoutResult":
         raise typer.Exit(1) from None
 
 
-def _print_delta_table(report: "DeltaReport") -> None:
+def _print_delta_table(report: DeltaReport) -> None:
     """Pretty-print a delta report as a table."""
     # Warnings to stderr
     for w in report.warnings:
@@ -378,7 +380,7 @@ def cache_clear(
     typer.echo("  Cache cleared.")
 
 
-def _print_table(result: "ScoutResult") -> None:
+def _print_table(result: ScoutResult) -> None:
     """Pretty-print results as a table to stderr/stdout."""
     typer.echo(f"\n  Entity: {result.entity.company_name}", err=True)
     if result.entity.location:

--- a/domain_scout/config.py
+++ b/domain_scout/config.py
@@ -1,5 +1,7 @@
 """Configuration constants and defaults."""
 
+from __future__ import annotations
+
 import dataclasses
 from dataclasses import dataclass, field
 from typing import Literal
@@ -120,7 +122,7 @@ class ScoutConfig:
         return dataclasses.asdict(self)
 
     @classmethod
-    def from_profile(cls, profile: ProfileName, **overrides: object) -> "ScoutConfig":
+    def from_profile(cls, profile: ProfileName, **overrides: object) -> ScoutConfig:
         """Create a config from a named profile with optional overrides."""
         if profile not in _PROFILES:
             raise ValueError(f"Unknown profile: {profile!r}. Choose from: {', '.join(_PROFILES)}")

--- a/domain_scout/delta.py
+++ b/domain_scout/delta.py
@@ -1,5 +1,7 @@
 """Delta reporting: compute differences between two ScoutResult runs."""
 
+from __future__ import annotations
+
 from domain_scout.models import (
     ChangedDomain,
     DeltaReport,

--- a/domain_scout/eval.py
+++ b/domain_scout/eval.py
@@ -9,6 +9,8 @@ Usage:
   python -m domain_scout.eval --mode live --output json
 """
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import math

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -1,5 +1,7 @@
 """Pydantic models for input, output, and intermediate data."""
 
+from __future__ import annotations
+
 from datetime import datetime  # noqa: TC003 — Pydantic needs runtime import
 from typing import Self
 

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -1341,7 +1341,7 @@ class Scout:
                 # Compare against all seed fingerprints, take best match
                 best_match = None
                 best_signal_count = 0
-                for _seed_domain, seed_fp in seed_fps.items():
+                for seed_fp in seed_fps.values():
                     fm = match_fingerprint(candidate_fp, seed_fp)
                     if fm.signal_count > best_signal_count:
                         best_match = fm

--- a/domain_scout/sources/dns_fingerprint.py
+++ b/domain_scout/sources/dns_fingerprint.py
@@ -322,7 +322,7 @@ def match_fingerprint(candidate: DNSFingerprint, seed: DNSFingerprint) -> Finger
     seed_ns = {ns for ns in seed.ns_zones if not _is_shared_ns(ns)}
     for nz in candidate.ns_zones:
         if nz in seed_ns:
-            signals.append(
+            signals.append(  # noqa: PERF401 — conditional append; not all iterations append
                 FingerprintSignal(
                     signal_type="ns_zone",
                     seed_value=nz,
@@ -338,7 +338,7 @@ def match_fingerprint(candidate: DNSFingerprint, seed: DNSFingerprint) -> Finger
     seed_spf = {s for s in seed.spf_includes if s not in _SHARED_SPF_INCLUDES}
     for spf in candidate.spf_includes:
         if spf in seed_spf:
-            signals.append(
+            signals.append(  # noqa: PERF401 — conditional append; not all iterations append
                 FingerprintSignal(
                     signal_type="spf_include",
                     seed_value=spf,

--- a/domain_scout/tests/test_models.py
+++ b/domain_scout/tests/test_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,19 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "B", "A", "SIM", "TCH"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "A", "SIM", "TCH", "PERF"]
+extend-select = ["S608"]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.per-file-ignores]
+"domain_scout/tests/**" = ["S101"]
+# S608 false positives: table names validated by allowlist or from internal Path objects
+"domain_scout/cache.py" = ["S608"]
+"domain_scout/resolve/gleif_ingest.py" = ["S608"]
+"domain_scout/resolve/gleif_lookup.py" = ["S608"]
+"domain_scout/sources/local_parquet.py" = ["S608"]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
## Root cause

~15 bot PRs were repeatedly making the same mechanical changes: adding/removing `from __future__ import annotations`, rewriting append-in-loops to `.extend`/comprehensions, and flagging SQL injection in parameterized queries. Root cause: the ruff config didn't enforce any of these, so they drifted and the bot kept re-finding them.

## What this PR does

### `from __future__ import annotations` (ends the add/remove churn)

Added `required-imports = ["from __future__ import annotations"]` under `[tool.ruff.lint.isort]`. Ruff auto-added the import to the 14 files that were missing it. From now on any file missing the import fails `ruff check` — the bot has nothing left to flip.

### `PERF` rules added to `lint.select`

Catches the append-in-loop patterns the bot kept flagging:
- **PERF102** (dict `.items()` when only values used): auto-fixed in `scout.py`
- **PERF401** (append-in-loop → extend): two sites in `dns_fingerprint.py` are conditional appends (`if x in set: append(...)`) where the refactor would be semantically wrong; suppressed with `# noqa: PERF401` explaining why

### `S608` added via `extend-select`

Enables SQL injection detection (what the security bot PRs were catching). All 11 flagged sites are false positives:
- `cache.py`: `{table}` is validated against `_VALID_TABLES = frozenset({"ct_cache", "rdap_cache"})` two lines above
- `gleif_ingest.py`: `{lei2_csv!s}` / `{rr_csv!s}` are `Path` objects from `NamedTemporaryFile`, not user input
- `gleif_lookup.py`: `{sub_count_join}` is a hardcoded JOIN clause string constant
- `local_parquet.py`: `{self._from_clause}` is an internal attribute

Suppressed via `per-file-ignores` in pyproject.toml with a comment explaining the pattern. Future real S608 violations in *other* files will still fire.

### TC003 fix in `api.py`

Adding `from __future__ import annotations` surfaced a pre-existing TC003: `AsyncIterator` imported at runtime but only used in type annotations. Moved to `TYPE_CHECKING` block (safe with PEP 563 lazy evaluation).

## Auto-fixes applied

`uv run ruff check --fix . && uv run ruff format .` made all changes — no manual rewrites beyond the two `# noqa: PERF401` annotations and the TC003 fix.

## Verification

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
50 files already formatted

$ uv run pytest domain_scout/tests -m "not integration" -q
641 passed, 4 deselected, 2 warnings in 4.85s

$ uv run mypy domain_scout/ --ignore-missing-imports
Success: no issues found in 50 source files
```