### PR TITLE
Fix README + docs quick-start: examples omit the required scout subcommand (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,28 @@ uv sync --all-groups --all-extras
 ```bash
 # Quickest start — use CTScout API (free key from https://ctscout.dev)
 export CTSCOUT_API_KEY=ds_free_...
-domain-scout --name "Goldman Sachs"
+domain-scout scout --name "Goldman Sachs"
 
 # Or pass the key directly
-domain-scout --name "Goldman Sachs" --api-key ds_free_...
+domain-scout scout --name "Goldman Sachs" --api-key ds_free_...
 
 # Basic usage (queries crt.sh directly, no API key needed)
-domain-scout --name "Cloudflare" --location "San Francisco, CA"
+domain-scout scout --name "Cloudflare" --location "San Francisco, CA"
 
 # With seed domain
-domain-scout --name "Palo Alto Networks" --location "Santa Clara, CA" --seed "paloaltonetworks.com"
+domain-scout scout --name "Palo Alto Networks" --location "Santa Clara, CA" --seed "paloaltonetworks.com"
 
 # Multiple seeds — cross-verification boosts confidence for domains found by both
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com
 
 # Deep mode — GeoDNS global resolution for non-resolving domains
-domain-scout --name "Walmart" --seed "walmart.com" --deep
+domain-scout scout --name "Walmart" --seed "walmart.com" --deep
 
 # JSON output
-domain-scout --name "Acme Corp" --output json > results.json
+domain-scout scout --name "Acme Corp" --output json > results.json
 
 # Verbose logging
-domain-scout --name "Cloudflare" --seed "cloudflare.com" -v
+domain-scout scout --name "Cloudflare" --seed "cloudflare.com" -v
 ```
 
 ### REST API

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@ config = ScoutConfig.from_profile("strict")    # higher thresholds
 config = ScoutConfig.from_profile("broad", total_timeout=200)
 ```
 
-Or via CLI: `domain-scout --name "Acme" --seed acme.com --profile strict`
+Or via CLI: `domain-scout scout --name "Acme" --seed acme.com --profile strict`
 
 ## Response models
 

--- a/docs/deep-mode.md
+++ b/docs/deep-mode.md
@@ -25,13 +25,13 @@ After Phase 3 (DNS resolution), deep mode:
 ## Usage
 
 ```bash
-domain-scout --name "Walmart" --seed "walmart.com" --deep
+domain-scout scout --name "Walmart" --seed "walmart.com" --deep
 ```
 
 Multi-seed and deep mode combine well for comprehensive discovery:
 
 ```bash
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com --deep
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com --deep
 ```
 
 The `--deep` flag automatically bumps the timeout to at least 180s (from the default 120s) to account for the additional HTTP round-trips. Using 3+ seeds bumps to at least 150s.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@ Real-world results demonstrating domain-scout's capabilities.
 A multinational retailer with subsidiaries across Mexico, South Africa, UK, India, and China.
 
 ```bash
-domain-scout --name "Walmart" --seed "walmart.com" --deep
+domain-scout scout --name "Walmart" --seed "walmart.com" --deep
 ```
 
 **17 domains found** including:
@@ -33,7 +33,7 @@ All discovered through Certificate Transparency SAN co-occurrence + organization
 An Italian multinational financial services company operating across Europe, Middle East, and Asia.
 
 ```bash
-domain-scout --name "Generali" --seed "generali.it"
+domain-scout scout --name "Generali" --seed "generali.it"
 ```
 
 **43 domains found** across multiple countries:
@@ -73,7 +73,7 @@ The `.com` seed finds 14 additional investment-related domains (e.g., `generali-
 **Takeaway:** For multinational organizations, use multiple seeds to get the full picture:
 
 ```bash
-domain-scout --name "Generali" --seed generali.it --seed generali.com
+domain-scout scout --name "Generali" --seed generali.it --seed generali.com
 ```
 
 This finds the union of both seed sets (73+ unique domains) with cross-verified overlap domains scored at 0.90+ confidence.
@@ -83,7 +83,7 @@ This finds the union of both seed sets (73+ unique domains) with cross-verified 
 When using multiple seeds, domains discovered independently from 2+ seeds receive a `cross_seed_verified` source with a 0.90 base score:
 
 ```bash
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com
 ```
 
 If both seeds independently discover `walmartlabs.com` through separate CT searches, that convergence is a strong ownership signal. The seeds themselves may also share certificates, proving common ownership.
@@ -93,7 +93,7 @@ If both seeds independently discover `walmartlabs.com` through separate CT searc
 Shelter Insurance uses DV certificates — CT org search finds nothing useful. Fingerprint mode discovers subsidiaries via shared Proofpoint MX tenant:
 
 ```bash
-domain-scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
+domain-scout scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
 ```
 
 **Default mode:** 3 domains (shelterinsurance.com, sayinsurance.com, cloudflaressl.com)

--- a/docs/fingerprint-mode.md
+++ b/docs/fingerprint-mode.md
@@ -83,10 +83,10 @@ Fingerprint signals map to existing corroboration tiers:
 
 ```bash
 # Basic fingerprint mode
-domain-scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
+domain-scout scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
 
 # JSON output for programmatic use
-domain-scout --name "Company" --seed company.com --mode fingerprint -o json
+domain-scout scout --name "Company" --seed company.com --mode fingerprint -o json
 ```
 
 Fingerprint mode automatically implies `--deep` (GeoDNS) and sets the timeout to at least 180 seconds.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,13 +28,13 @@ The fastest way to get started — no local data pipeline needed:
 
 ```bash
 export CTSCOUT_API_KEY=ds_free_...
-domain-scout --name "Goldman Sachs"
+domain-scout scout --name "Goldman Sachs"
 ```
 
 Or pass the key directly:
 
 ```bash
-domain-scout --name "Goldman Sachs" --api-key ds_free_...
+domain-scout scout --name "Goldman Sachs" --api-key ds_free_...
 ```
 
 The free tier gives you 10 queries/day against 147K+ org-domain pairs. No local setup, no database, no crt.sh dependency.
@@ -44,7 +44,7 @@ The free tier gives you 10 queries/day against 147K+ org-domain pairs. No local 
 Without an API key, domain-scout queries crt.sh directly:
 
 ```bash
-domain-scout --name "Cloudflare" --seed "cloudflare.com"
+domain-scout scout --name "Cloudflare" --seed "cloudflare.com"
 ```
 
 Output:
@@ -66,7 +66,7 @@ Output:
 When an entity owns multiple domains that don't share certificates, a single seed only discovers part of the picture. Use `--seed` multiple times for cross-verification:
 
 ```bash
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com
 ```
 
 Domains independently discovered from 2+ seeds receive a `cross_seed_verified` confidence boost (0.90 base score), providing a strong convergence signal.
@@ -96,7 +96,7 @@ Domains independently discovered from 2+ seeds receive a `cross_seed_verified` c
 ## JSON output
 
 ```bash
-domain-scout --name "Acme Corp" --seed "acme.com" --output json > results.json
+domain-scout scout --name "Acme Corp" --seed "acme.com" --output json > results.json
 ```
 
 The JSON output is a self-contained audit artifact. Each domain includes structured `evidence` records (source type, cert ID, org name, similarity score) and the top-level `run_metadata` captures tool version, timestamp, and the full config snapshot used. See [API Reference](api.md) for the complete schema.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,19 +22,19 @@ domain-scout handles all of these by cross-referencing multiple data sources and
 uv sync
 
 # Run
-domain-scout --name "Walmart" --seed "walmart.com"
+domain-scout scout --name "Walmart" --seed "walmart.com"
 
 # Multiple seeds for cross-verification
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com
 
 # Discovery profiles (broad/balanced/strict)
-domain-scout --name "Walmart" --seed walmart.com --profile strict
+domain-scout scout --name "Walmart" --seed walmart.com --profile strict
 
 # Deep mode for global resolution
-domain-scout --name "Walmart" --seed "walmart.com" --deep
+domain-scout scout --name "Walmart" --seed "walmart.com" --deep
 
 # Fingerprint mode for DV-cert companies (no org in certs)
-domain-scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
+domain-scout scout --name "Shelter Insurance" --seed shelterinsurance.com --mode fingerprint
 ```
 
 ## Documentation

--- a/docs/multi-seed.md
+++ b/docs/multi-seed.md
@@ -28,13 +28,13 @@ Neither seed alone sees the full picture. The `.it` seed finds Czech/Italian/Slo
 
 ```bash
 # Single seed (backward compatible)
-domain-scout --name "Walmart" --seed walmart.com
+domain-scout scout --name "Walmart" --seed walmart.com
 
 # Multiple seeds
-domain-scout --name "Walmart" --seed walmart.com --seed samsclub.com
+domain-scout scout --name "Walmart" --seed walmart.com --seed samsclub.com
 
 # Three seeds with deep mode
-domain-scout --name "Generali" --seed generali.it --seed generali.com --seed generali.de --deep
+domain-scout scout --name "Generali" --seed generali.it --seed generali.com --seed generali.de --deep
 ```
 
 The `--seed` flag is repeatable. Using 3+ seeds auto-bumps timeout to 150s.


### PR DESCRIPTION
Closes #162.

## Premise check

`scout` was never removed — it has existed since the initial OSS release. The docs simply omit it: every quick-start example reads `domain-scout --name ...`, which Typer rejects (`No such option: --name`) because a subcommand is required. A stranger's first command fails in their first minute. The issue specs the fix as correcting the docs, which this does — **docs-only, zero code changed**.

## Verification = "the README is true"

All 8 quick-start examples were run **verbatim from a cold `uv sync --frozen`**, before (all fail identically) and after (all exit 0), including: real result tables for the seeded Palo Alto/Walmart examples, valid JSON from the `--output json` example, graceful 401 warning on the placeholder API key, and `--deep` completing with geodns rescue. Every rewritten example in docs/ additionally parse-checked against `scout --help` (zero "No such option"); `grep -rn 'domain-scout --name'` across README+docs → 0 remaining. `serve`/`diff`/`cache`/`gleif-ingest` and Docker examples untouched per the issue spec.

Gates (exact CI commands): 641 passed / 4 deselected, coverage 92.73% (≥92 gate), ruff + format clean, mypy clean, `mkdocs build --strict` clean.

Self-review: (a) nothing clever — 31 mechanical insertions of one word; (b) all counts above are from actual command output during the cold-run session; (c) matches the docs' existing command style.

Two observations parked as candidates for separate issues: a typo'd API key yields a warning + "No domains found" instead of a hard error (rough first-run UX), and the repo CLAUDE.md's "565 unit tests" has drifted (actual 641).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkFRcZ66XGotbQuSgDEanr