### PR TITLE
Reject substring / generic-word / single-city-token matches in ct_org_match (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collisions, producing single-entity wrong-owner attributions that no frequency
   filter caught (e.g. Munich Re → UniCredit/HVB banking domains, Promutuel →
   Liberty Mutual). The new gate (`strict_org_name_match`, ported from
-  insurance-market-db#200) rejects those classes while preserving exact and
-  legal-suffixed matches. This is precision-first, so some legitimate matches
-  are also dropped: acronym-only cert-org matches (cert org `IBM` for target
-  `International Business Machines`) and multi-word targets that share only one
-  distinctive token with the cert org (`Sompo Holdings` vs `Sompo Japan
-  Insurance`) are no longer promoted to `ct_org_match`. Other sources and
+  insurance-market-db#200) rejects those classes while preserving exact,
+  legal-suffixed, hyphenated (`Coca-Cola` → `Coca-Cola Company`), and
+  abbreviation-form (`Palo Alto Tech` → `Palo Alto Tech Inc`) matches. The
+  distinctive core and the certificate text now undergo identical normalization
+  — hyphens fold to spaces on both sides and abbreviations are never expanded —
+  so byte-identical names always match (an initial port drift folded the text
+  but not the core, dropping every hyphenated/abbreviated name). This is
+  precision-first, so some legitimate matches are still intentionally dropped:
+  acronym-only cert-org matches (cert org `IBM` for target `International
+  Business Machines`) and multi-word targets that share only one distinctive
+  token with the cert org (`Sony Group` vs `Sony Corporation`, `Sompo Holdings`
+  vs `Sompo Japan Insurance`) are not promoted to `ct_org_match` — the ≥2
+  significant-token rule that rejects generic-word/city collisions (`Zurich
+  Insurance Group` vs `Zurich Airport`) also requires the stripped generic word
+  to reappear. This recall limitation is shared verbatim with the reference and
+  left as-is: the reviewer-suggested relaxations all reintroduce the city-
+  collision false positives the rule defends against. Other sources and
   thresholds are unchanged. (#174)
 - `CTLogSource.search_by_org` now raises `CTOrgSearchUnavailableError` when the
   crt.sh Postgres backend is unavailable and org verification is required,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The `ct_org_match` source now requires a strict word-bounded org-name match in
+  addition to the fuzzy `org_match_threshold`. The fuzzy scorer credited
+  raw-substring hits (`Aon` in `kaonavi`, `Generali` in `Generalist`),
+  generic-word overlap (`… Insurance Group`), and bare single-token/city
+  collisions, producing single-entity wrong-owner attributions that no frequency
+  filter caught (e.g. Munich Re → UniCredit/HVB banking domains, Promutuel →
+  Liberty Mutual). The new gate (`strict_org_name_match`, ported from
+  insurance-market-db#200) rejects those classes while preserving exact and
+  legal-suffixed matches. This is precision-first, so some legitimate matches
+  are also dropped: acronym-only cert-org matches (cert org `IBM` for target
+  `International Business Machines`) and multi-word targets that share only one
+  distinctive token with the cert org (`Sompo Holdings` vs `Sompo Japan
+  Insurance`) are no longer promoted to `ct_org_match`. Other sources and
+  thresholds are unchanged. (#174)
 - `CTLogSource.search_by_org` now raises `CTOrgSearchUnavailableError` when the
   crt.sh Postgres backend is unavailable and org verification is required,
   instead of silently returning `[]` (the JSON fallback cannot verify subject

--- a/domain_scout/matching/entity_match.py
+++ b/domain_scout/matching/entity_match.py
@@ -328,6 +328,116 @@ def _org_name_similarity_cached(name_a: str, name_b: str) -> float:
     return best
 
 
+# ── Strict org-name gate for ct_org_match (issue #174) ─────────────────────
+# Ported from insurance-market-db#200 (scripts/shared/features.py::
+# entity_name_match). ``org_name_similarity`` is a fuzzy float scorer, so it
+# credits raw-substring hits ("Aon" in "kaonavi", "Generali" in "Generalist"),
+# near-duplicate tokens, and generic-word overlap ("… Insurance Group") — which
+# produce single-entity, wrong-owner attributions that no frequency filter can
+# catch (insurance-market-db#56: Munich Re → UniCredit/HVB banking domains,
+# Promutuel → Liberty Mutual). This boolean check is required IN ADDITION to the
+# fuzzy threshold for the ``ct_org_match`` source only: the target's distinctive
+# core must appear in the cert org as a word-bounded phrase, and multi-word
+# targets need ≥2 significant tokens bounded. Precision-first — a miss just drops
+# a low-signal cert; a false hit poisons downstream attribution DBs.
+
+_NONALNUM_SPACE_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_MULTI_SPACE_RE = re.compile(r"\s+")
+
+# Generic/industry words that carry no distinctive identity. Stripped only as a
+# TRAILING suffix so middle tokens survive ("AXA Insurance UK" keeps "insurance").
+# Mirrors the extras in features.build_suffix_pattern (insurance-market-db#200).
+_GENERIC_CORE_WORDS = (
+    "group",
+    "holdings",
+    "holding",
+    "enterprises",
+    "international",
+    "reinsurance",
+    "assurance",
+    "insurance",
+    "versicherung",
+    "mutuelle",
+    "mutual",
+    "casualty",
+    "indemnity",
+    "underwriters",
+)
+_GENERIC_TRAILING_RE = re.compile(r"\s+(?:" + "|".join(_GENERIC_CORE_WORDS) + r")$")
+
+
+def _has_cjk(s: str) -> bool:
+    """True if the string contains East Asian (unspaced) characters."""
+    return any(
+        "　" <= c <= "鿿"  # CJK ideographs + kana
+        or "＀" <= c <= "￯"  # fullwidth forms
+        or "가" <= c <= "힣"  # Hangul syllables
+        for c in s
+    )
+
+
+def _fold_text(text: str) -> str:
+    """Fold to a bounded-match space: lowercase, strip accents (Latin only),
+    replace punctuation with spaces.
+
+    CJK is left un-decomposed — NFKD changes character identity for East Asian
+    text (katakana dakuten: ジ → シ) and there are no word boundaries to anchor.
+    """
+    lowered = text.lower()
+    folded = lowered if _has_cjk(lowered) else _strip_accents(lowered)
+    folded = _NONALNUM_SPACE_RE.sub(" ", folded).replace("_", " ")
+    return _MULTI_SPACE_RE.sub(" ", folded).strip()
+
+
+def _distinctive_core(name: str) -> str:
+    """Suffix-stripped distinctive core of an org name.
+
+    Latin names compose on ``normalize_org_name`` (strips legal forms and
+    trailing Group/AG/SE/… without the GLEIF ELF list) plus a trailing
+    generic/industry-word strip. CJK names are folded but never suffix-stripped
+    (the suffix lists are Latin).
+    """
+    if _has_cjk(name):
+        return _fold_text(name)
+    core = normalize_org_name(name)
+    while True:
+        stripped = _GENERIC_TRAILING_RE.sub("", core).strip()
+        if stripped == core or not stripped:
+            break
+        core = stripped
+    return core
+
+
+def _significant_words(name: str) -> list[str]:
+    """Folded tokens of length > 2 from the raw name (for the ≥2-token rule)."""
+    cleaned = _NONALNUM_SPACE_RE.sub(" ", name.lower())
+    return [_strip_accents(w) for w in {w for w in cleaned.split() if len(w) > 2}]
+
+
+def strict_org_name_match(entity: str, text: str) -> bool:
+    """Precision-first check that ``entity`` actually names the org in ``text``.
+
+    Ported from insurance-market-db#200. Rejects the wrong-owner classes the
+    fuzzy scorer credits — raw-substring hits, generic-word-only overlap, and
+    bare city / single-token collisions — while preserving exact and
+    legal-suffixed matches.
+    """
+    core = _distinctive_core(entity)
+    if not core or not text:
+        return False
+    text_norm = _fold_text(text)
+    if _has_cjk(core):
+        # Unspaced scripts have no word boundaries — containment is the match.
+        return core in text_norm
+    if not re.search(rf"\b{re.escape(core)}\b", text_norm):
+        return False
+    words = _significant_words(entity)
+    if len(words) >= 2:
+        hits = sum(1 for w in words if re.search(rf"\b{re.escape(w)}\b", text_norm))
+        return hits >= 2
+    return True
+
+
 def domain_from_company_name(company_name: str) -> list[str]:
     """Generate plausible domain slugs from a company name.
 

--- a/domain_scout/matching/entity_match.py
+++ b/domain_scout/matching/entity_match.py
@@ -89,7 +89,7 @@ def _extract_dba_name(name: str) -> str | None:
 
 
 @functools.lru_cache(maxsize=4096)
-def normalize_org_name(name: str) -> str:
+def normalize_org_name(name: str, expand_abbreviations: bool = True) -> str:
     """Normalize a company/org name for comparison.
 
     - Normalizes unicode (strips accents)
@@ -98,6 +98,13 @@ def normalize_org_name(name: str) -> str:
     - Lowercases and collapses whitespace
     - Removes leading "The"
     - Expands abbreviations (intl→international, tech→technology, etc.)
+
+    ``expand_abbreviations`` defaults to True (fuzzy-scorer behaviour). The
+    strict ``ct_org_match`` core builder passes False: the cert text is never
+    abbreviation-expanded, so an expanded core ("…technology") could never
+    appear word-bounded in the raw text ("…tech") — see ``_distinctive_core``
+    / issue #174, which mirrors the reference ``features.normalize_name`` (no
+    abbrev map).
     """
     name = _strip_accents(name)
     # Strip DBA / subsidiary clauses before suffix removal
@@ -122,6 +129,8 @@ def normalize_org_name(name: str) -> str:
     name = re.sub(r"^the\s+", "", name)
     # Expand common abbreviations
     words = name.split()
+    if not expand_abbreviations:
+        return " ".join(words)
     return " ".join(_ABBREVIATIONS.get(w, w) for w in words)
 
 
@@ -396,10 +405,19 @@ def _distinctive_core(name: str) -> str:
     trailing Group/AG/SE/… without the GLEIF ELF list) plus a trailing
     generic/industry-word strip. CJK names are folded but never suffix-stripped
     (the suffix lists are Latin).
+
+    The core is built WITHOUT abbreviation expansion and then folded through the
+    same ``_fold_text`` transform used on the cert text, so hyphens become
+    spaces on BOTH sides. Without this a hyphenated core ("coca-cola") or an
+    expanded abbreviation could never appear word-bounded in the space-folded,
+    unexpanded text — issue #174 review (findings 1 & 2). This mirrors the
+    reference ``features.normalize_name`` (hyphen→space, no abbrev map).
     """
     if _has_cjk(name):
         return _fold_text(name)
-    core = normalize_org_name(name)
+    # Fold immediately after normalize (before the generic-trailing loop) so a
+    # hyphen-glued trailing generic word ("Foo-Group") is also strippable.
+    core = _fold_text(normalize_org_name(name, expand_abbreviations=False))
     while True:
         stripped = _GENERIC_TRAILING_RE.sub("", core).strip()
         if stripped == core or not stripped:

--- a/domain_scout/matching/entity_match.py
+++ b/domain_scout/matching/entity_match.py
@@ -427,7 +427,17 @@ def _distinctive_core(name: str) -> str:
 
 
 def _significant_words(name: str) -> list[str]:
-    """Folded tokens of length > 2 from the raw name (for the ≥2-token rule)."""
+    """Folded tokens of length > 2 from the raw name (for the ≥2-token rule).
+
+    Deliberately tokenizes the RAW name (not the suffix-stripped core). A
+    legal-suffix word ("Corp"/"Ltd") therefore counts toward the ≥2 rule, so
+    "Bayer Corp" needs "corp" in the cert text too — a known recall gap (#174
+    review finding 3). Stripping suffixes here to close it is unsafe: it
+    collapses "X Corp"/"X Group" to the lone token "X", which then matches any
+    unrelated "X …" org ("Sony Group"→"Sony Airport", "General Corp"→"General
+    Motors") — reintroducing the exact single-token collision this file exists
+    to kill. Left conservative on purpose.
+    """
     cleaned = _NONALNUM_SPACE_RE.sub(" ", name.lower())
     return [_strip_accents(w) for w in {w for w in cleaned.split() if len(w) > 2}]
 
@@ -439,7 +449,19 @@ def strict_org_name_match(entity: str, text: str) -> bool:
     fuzzy scorer credits — raw-substring hits, generic-word-only overlap, and
     bare city / single-token collisions — while preserving exact and
     legal-suffixed matches.
+
+    Truncate BEFORE the cached call: ``text`` is an untrusted crt.sh subject
+    O= field with no upstream length cap, and the key must stay bounded —
+    same 500-char guard ``org_name_similarity`` applies (#174 review).
     """
+    return _strict_org_name_match_cached(entity[:500], text[:500])
+
+
+@functools.lru_cache(maxsize=4096)
+def _strict_org_name_match_cached(entity: str, text: str) -> bool:
+    """Cached impl — callers pre-truncate. ``entity``/``company_name`` is
+    constant across a whole crt.sh result loop, so memoizing avoids
+    re-normalizing the same target per record."""
     core = _distinctive_core(entity)
     if not core or not text:
         return False

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -32,6 +32,7 @@ from domain_scout.matching.entity_match import (
     domain_from_company_name,
     normalize_org_name,
     org_name_similarity,
+    strict_org_name_match,
 )
 from domain_scout.models import (
     DiscoveredDomain,
@@ -825,6 +826,12 @@ class Scout:
         similarity = org_name_similarity(cert_org, org_name)
         if similarity < self.config.org_match_threshold:
             return results
+        # Precision gate for ct_org_match: the fuzzy score credits substring,
+        # generic-word, and single-city-token matches that produce wrong-owner
+        # attributions no frequency filter catches (#174). Require a strict
+        # word-bounded name match too. Subsidiary tags keep their looser intent.
+        if source_tag == "ct_org_match" and not strict_org_name_match(org_name, cert_org):
+            return results
 
         sans = _extract_sans(rec)
         cn = rec.get("common_name", "")
@@ -974,7 +981,11 @@ class Scout:
                 if isinstance(cert_org, str) and cert_org:
                     accum.cert_org_names.add(cert_org)
                     sim = org_name_similarity(cert_org, company_name)
-                    if sim >= self.config.org_match_threshold:
+                    # Strict word-bounded gate on top of the fuzzy threshold —
+                    # see _process_org_record (#174).
+                    if sim >= self.config.org_match_threshold and strict_org_name_match(
+                        company_name, cert_org
+                    ):
                         accum.sources.add("ct_org_match")
                         desc = f"Cert org '{cert_org}' matches target (score={sim:.2f})"
                         accum.evidence.append(

--- a/domain_scout/tests/test_matching.py
+++ b/domain_scout/tests/test_matching.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -11,6 +12,7 @@ from domain_scout.matching.entity_match import (
     domain_from_company_name,
     normalize_org_name,
     org_name_similarity,
+    strict_org_name_match,
 )
 
 
@@ -522,3 +524,81 @@ class TestPropertyBased:
             assert score == 1.0
         else:
             assert score == 0.0
+
+
+class TestStrictOrgNameMatch:
+    """Word-bounded precision gate for the ct_org_match source (issue #174).
+
+    Ported from insurance-market-db#200 (tests/test_shared_features.py::
+    test_entity_name_match). Signature is strict_org_name_match(entity, text)
+    where ``entity`` is the target company and ``text`` is the certificate org.
+    """
+
+    # The insurance-market-db#200 regression matrix, ported verbatim.
+    @pytest.mark.parametrize(
+        "entity,text,expected",
+        [
+            # single-brand entities: the bounded core must appear
+            ("Chubb", "© 2026 Chubb Limited. All rights reserved.", True),
+            ("Chubb", "© 2026 Acme Holdings", False),
+            ("Allianz SE", "© Allianz 2026. All Rights Reserved.", True),
+            # multi-word: bounded core AND >=2 significant words
+            ("Zurich Insurance Group", "Zurich Insurance Group Ltd", True),
+            # SUBSTRING false positives must never match (word boundaries):
+            ("AXA", "© 2026 MAXAIR Industries", False),
+            ("Generali", "© The Generalist", False),
+            ("Aviva", "© Avivagen Animal Health", False),
+            ("ERGO Group", "© Allergology Ergonomics Group", False),
+            # generic-suffix overlap alone must never match:
+            ("Zurich Insurance Group", "© 2026 Allianz Insurance Group", False),
+            # city/brand collisions: bare city word is not the entity
+            ("Zurich Insurance Group", "© 2026 Zurich Airport", False),
+            ("Munich Re", "© 2026 Munich Airport", False),
+            ("Munich Re", "UniCredit Bank GmbH", False),
+            ("Munich Re", "© 2026 Munich Re", True),
+            # bounded phrase: 'munich re' is not a prefix-match of 'reinsurance'
+            ("Munich Re", "Munich Reinsurance content page", False),
+            # sibling legal entities: core phrase must match exactly
+            ("AXA Insurance UK plc", "© AXA Insurance dac", False),
+            # accent folding must apply to BOTH sides
+            ("Länsförsäkringar AB", "© Länsförsäkringar AB 2026", True),
+            # CJK: no word boundaries in unspaced scripts — containment is match
+            ("東京海上ホールディングス", "© 東京海上ホールディングス株式会社 2026", True),
+            ("東京海上ホールディングス", "© 損保ジャパン株式会社 2026", False),
+            ("", "anything", False),
+            ("Chubb", "", False),
+        ],
+    )
+    def test_regression_matrix(self, entity: str, text: str, expected: bool) -> None:
+        assert strict_org_name_match(entity, text) is expected
+
+    # domain-scout's own documented wrong-owner attributions (#174 / #56):
+    # cert_org is the certificate subject org; entity is our search target.
+    @pytest.mark.parametrize(
+        "entity,cert_org",
+        [
+            ("Aon", "kaonavi Inc"),  # substring: 'aon' inside 'kaonavi'
+            ("Munich Re", "UniCredit Bank GmbH"),  # → 26 HVB/UniCredit domains
+            ("Munich Re", "Hypo Vereinsbank"),  # HVB, different industry
+            ("Promutuel Insurance", "Liberty Mutual Insurance"),  # → 13 Liberty
+            ("Everest", "Pinterest"),  # substring: 'everest' inside 'pinterest'
+        ],
+    )
+    def test_wrong_owner_pairs_rejected(self, entity: str, cert_org: str) -> None:
+        assert strict_org_name_match(entity, cert_org) is False
+
+    # Legitimate matches must survive (TP preservation — pulled from the
+    # existing acceptance/similarity fixtures so we don't over-tighten).
+    @pytest.mark.parametrize(
+        "entity,cert_org",
+        [
+            ("Walmart", "Walmart Inc."),  # test_acceptance fixture
+            ("Walmart", "Walmart Canada Corp."),  # test_acceptance fixture
+            ("Palo Alto Networks", "Palo Alto Networks, Inc."),  # test_real_world
+            ("Guidewire Software", "Guidewire Software, Inc."),  # test_real_world
+            ("Munich Re", "Munich Re Group"),  # generic-suffix positive
+            ("Zurich Insurance Group", "Zurich Insurance Company Ltd"),
+        ],
+    )
+    def test_legitimate_matches_preserved(self, entity: str, cert_org: str) -> None:
+        assert strict_org_name_match(entity, cert_org) is True

--- a/domain_scout/tests/test_matching.py
+++ b/domain_scout/tests/test_matching.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from domain_scout.matching.entity_match import (
     _BRAND_ALIAS_PAIRS,
@@ -14,6 +19,30 @@ from domain_scout.matching.entity_match import (
     org_name_similarity,
     strict_org_name_match,
 )
+
+# Best-effort import of the insurance-market-db reference (features.entity_name_match)
+# for the differential-parity guard below. domain-scout is public/MIT and MUST NOT
+# hard-depend on that private repo — the import is optional and the differential
+# test skips cleanly when the reference is absent (CI, other machines). Set
+# DOMAIN_SCOUT_REF_FEATURES to the reference `scripts/` dir to override the default.
+_reference_entity_name_match: Callable[[str, str], bool] | None = None
+try:  # pragma: no cover - environment-dependent
+    import os as _os
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _ref_scripts = _Path(
+        _os.environ.get(
+            "DOMAIN_SCOUT_REF_FEATURES", _Path.home() / "insurance-market-db" / "scripts"
+        )
+    )
+    if _ref_scripts.is_dir():
+        _sys.path.insert(0, str(_ref_scripts))
+        from shared.features import entity_name_match as _entity_name_match
+
+        _reference_entity_name_match = _entity_name_match
+except Exception:  # pragma: no cover - reference optional
+    _reference_entity_name_match = None
 
 
 class TestNormalize:
@@ -602,3 +631,110 @@ class TestStrictOrgNameMatch:
     )
     def test_legitimate_matches_preserved(self, entity: str, cert_org: str) -> None:
         assert strict_org_name_match(entity, cert_org) is True
+
+    # (a) Exact-name round-trip property: a name must always match itself. This
+    # is the guard that would have caught #174 finding 1 — the hyphen-preserving
+    # core vs hyphen-folding text made byte-identical names return False.
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # hyphenated brands (finding 1)
+            "Coca-Cola",
+            "Hewlett-Packard",
+            "Mercedes-Benz",
+            "Anheuser-Busch",
+            "Rolls-Royce",
+            "Bristol-Myers",
+            # abbreviation forms (finding 2)
+            "Palo Alto Tech",
+            "Acme Intl",
+            # single-word brands
+            "Walmart",
+            "Chubb",
+            "Visa",
+            # multi-word
+            "Zurich Insurance Group",
+            "Munich Re",
+            "Berkshire Hathaway",
+            # accented + CJK (folding must apply on both sides)
+            "Länsförsäkringar",
+            "東京海上ホールディングス",
+        ],
+    )
+    def test_exact_name_roundtrip(self, name: str) -> None:
+        assert strict_org_name_match(name, name) is True
+
+    # (b) Hyphenated-brand and abbreviation-form true positives (findings 1 & 2):
+    # the distinctive core must match once hyphens fold to spaces and the core is
+    # built without abbreviation expansion.
+    @pytest.mark.parametrize(
+        "entity,cert_org",
+        [
+            ("Coca-Cola", "The Coca-Cola Company"),
+            ("Hewlett-Packard", "Hewlett-Packard Enterprise"),
+            ("Mercedes-Benz", "Mercedes-Benz Group AG"),
+            ("Rolls-Royce", "Rolls-Royce Holdings plc"),
+            ("Bristol-Myers", "Bristol-Myers Squibb"),
+            ("Palo Alto Tech", "Palo Alto Tech Inc"),
+            ("Acme Intl", "Acme Intl Ltd"),
+        ],
+    )
+    def test_hyphenated_and_abbrev_positives(self, entity: str, cert_org: str) -> None:
+        assert strict_org_name_match(entity, cert_org) is True
+
+    # (c) Differential parity against the insurance-market-db reference
+    # (features.entity_name_match). This is the guard that would have caught
+    # findings 1 & 2: every pair below MUST produce the same boolean in both the
+    # port and the reference. Skips cleanly when the private reference is absent.
+    #
+    # NOTE — intentional divergence NOT asserted here: on hyphen+multiword
+    # entities the reference under-matches (its significant-word tokenizer joins
+    # hyphens — "anheuserbusch" — then searches word-bounded, so it can never
+    # hit the space-folded text). The port's tokenizer splits hyphens, so e.g.
+    # strict_org_name_match("Anheuser-Busch InBev", "Anheuser-Busch InBev SA")
+    # is True (correct) while the reference returns False. The port is the more
+    # correct side; those cases are deliberately excluded from this parity set.
+    @pytest.mark.skipif(
+        _reference_entity_name_match is None,
+        reason="insurance-market-db reference (features.entity_name_match) not available",
+    )
+    @pytest.mark.parametrize(
+        "entity,text",
+        [
+            # finding-1 hyphenated positives
+            ("Coca-Cola", "Coca-Cola"),
+            ("Coca-Cola", "Coca-Cola Company"),
+            ("Hewlett-Packard", "Hewlett-Packard"),
+            ("Mercedes-Benz", "Mercedes-Benz Group"),
+            ("Rolls-Royce", "Rolls-Royce Holdings plc"),
+            ("Bristol-Myers", "Bristol-Myers Squibb"),
+            # finding-2 abbreviation positives
+            ("Palo Alto Tech", "Palo Alto Tech Inc"),
+            ("Acme Intl", "Acme Intl Ltd"),
+            # exact / legal-suffix true positives
+            ("Walmart", "Walmart Inc."),
+            ("Chubb", "© 2026 Chubb Limited"),
+            # substring / word-boundary false positives
+            ("AXA", "MAXAIR Industries"),
+            ("Aon", "kaonavi Inc"),
+            ("Generali", "The Generalist"),
+            ("Everest", "Pinterest"),
+            ("Munich Re", "UniCredit Bank GmbH"),
+            ("Promutuel Insurance", "Liberty Mutual Insurance"),
+            # generic-overlap + city-collision false positives (the ≥2 rule)
+            ("Zurich Insurance Group", "© 2026 Allianz Insurance Group"),
+            ("Zurich Insurance Group", "© 2026 Zurich Airport"),
+            # finding-3 shared recall limitation (both return False)
+            ("Sony Group", "Sony Corporation"),
+            ("AXA Group", "AXA S.A."),
+            ("The Hartford", "Hartford Insurance Company"),
+            # accent folding on both sides
+            ("Länsförsäkringar AB", "© Länsförsäkringar AB 2026"),
+            # CJK containment
+            ("東京海上ホールディングス", "© 東京海上ホールディングス株式会社"),
+            ("東京海上ホールディングス", "© 損保ジャパン株式会社"),
+        ],
+    )
+    def test_differential_parity_with_reference(self, entity: str, text: str) -> None:
+        assert _reference_entity_name_match is not None  # for type-checkers
+        assert strict_org_name_match(entity, text) is _reference_entity_name_match(entity, text)


### PR DESCRIPTION
Closes #174.

## Problem

`ct_org_match` accepted loose org-name matches → systematic wrong-owner attributions no frequency filter catches (`shared_entity_count=1`): **Munich Re → 26 UniCredit/HVB banking domains**, **Promutuel → 13 Liberty Mutual**, plus `AXA` inside `MAXAIR`, `Aon` inside `kaonavi`, `Generali` inside `Generalist`, and generic-suffix overlap ("Zurich **Insurance Group**" ↔ "Allianz **Insurance Group**").

## Fix

A boolean `strict_org_name_match(entity, cert_org)` AND-gate on top of the existing fuzzy score, scoped to `source_tag == "ct_org_match"` only (subsidiary/DNS sources keep their looser intent). Ports the strictness discipline from insurance-market-db's `entity_name_match` (#200, mechanically verified there):
1. word-bounded phrase match on the suffix-stripped **distinctive core** — never raw substrings;
2. ≥2 word-bounded significant tokens for multi-word targets — kills generic-suffix-only overlap;
3. accent-fold + CJK containment for unspaced scripts.

**FP rate 5/9 → 0/9. Zero true-positives lost** on the labeled matrix.

## Review trail (two adversarial passes)

The first review found a **blocker the tests missed**: the distinctive core kept hyphens (via `normalize_org_name`) while the cert text folded them to spaces (via `_fold_text`), so hyphenated brands — even `strict_org_name_match("Coca-Cola","Coca-Cola")` — returned False, silently dropping exact-name attributions on the live path. Fixed by making the core and the text undergo **identical** normalization: `core = _fold_text(normalize_org_name(name, expand_abbreviations=False))`, folding before the generic-word strip. This also closed the abbreviation-drift finding (`tech`→`technology` expanded in the core but not the text). Finding 3 (the ≥2-token rule dropping "AXA Group") was **documented, not implemented** — the suggested relaxation flips "Zurich Insurance Group" vs "Zurich **Airport**" to a false positive (asserted against by an existing test, and the reference shares the same recall limitation verbatim).

Second review verdict: **push, blocker closed, no new regression** — verified no token-mangling on `AT&T`/`3M`/`H&M`/`Ben & Jerry's`, the empty-core guard holds (no match-all), every other `normalize_org_name` caller keeps abbreviation expansion (default unchanged), and all eight FP pairs still reject with exact reference parity.

## Verification

- 724 passed / 1 skipped (full non-integration suite), coverage 92.91% ≥ 92 gate.
- New tests: exact-name round-trip property (hyphenated/abbrev/single/multi/accented/CJK — the CI-durable guard against this exact re-drift), hyphenated+abbreviation TP fixtures, and a differential parity test vs the reference (24 pairs, runs locally where the private repo exists).
- ruff + mypy clean. ds-api blast radius: 186 passed against this library version.

**Known recall tradeoffs (precision-first, per the issue, documented in CHANGELOG):** acronym-only cert-org matches ("IBM" for "International Business Machines") and multi-word targets sharing only one distinctive token with a differently-wrapped cert org ("Sompo Holdings" vs "Sompo Japan Insurance") are dropped from `ct_org_match`. Exact-name and legal-suffixed positives are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkFRcZ66XGotbQuSgDEanr