### PR TITLE
Add connect_timeout to crt.sh Postgres connections (#165)

### DIFF
--- a/domain_scout/config.py
+++ b/domain_scout/config.py
@@ -34,6 +34,9 @@ class ScoutConfig:
 
     # --- Timeouts (seconds) ---
     postgres_timeout: int = 15
+    # Bounds the TCP connect to crt.sh Postgres; without it a black-holed host
+    # blocks for the OS TCP timeout (~2 min) while holding the CT semaphore (#165).
+    postgres_connect_timeout: int = 10
     http_timeout: int = 15
     dns_timeout: float = 5.0
     total_timeout: int = 90

--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -283,6 +283,7 @@ class CTLogSource:
             port=self._cfg.crtsh_postgres_port,
             dbname=self._cfg.crtsh_postgres_db,
             user=self._cfg.crtsh_postgres_user,
+            connect_timeout=self._cfg.postgres_connect_timeout,
         )
         conn.set_session(autocommit=True)
         return conn

--- a/domain_scout/tests/test_ct.py
+++ b/domain_scout/tests/test_ct.py
@@ -559,6 +559,19 @@ class TestOrgSearchFallbackUnavailable:
         assert any("CT org search unavailable" in e for e in result.run_metadata.errors)
 
 
+class TestPgConnect:
+    """Connection-level behavior for the crt.sh Postgres backend."""
+
+    def test_connect_passes_connect_timeout(self) -> None:
+        """_connect_pg must bound the TCP connect via connect_timeout (#165)."""
+        config = ScoutConfig(postgres_connect_timeout=7)  # non-default proves config wiring
+        ct = CTLogSource(config)
+        with patch("domain_scout.sources.ct_logs.psycopg2.connect") as mock_connect:
+            ct._connect_pg()
+        mock_connect.assert_called_once()
+        assert mock_connect.call_args.kwargs["connect_timeout"] == 7
+
+
 class TestPropertyBased:
     """Property-based tests using hypothesis."""
 


### PR DESCRIPTION
## What / Why

`_connect_pg` (`domain_scout/sources/ct_logs.py`) set `statement_timeout` only *after* the connection was established. The `psycopg2.connect(...)` call itself had no `connect_timeout`, so if crt.sh Postgres black-holes traffic (packets dropped vs. connection-refused), the connect blocks for the OS TCP timeout (~2 min) inside a default-executor thread — while holding the CT query semaphore. With `postgres_max_retries` this multiplies, starving the shared thread pool and blowing past `total_timeout` accounting.

This adds a bounded `postgres_connect_timeout` ScoutConfig knob (default **10s**) and passes it to `psycopg2.connect`. Connect-level failures now surface as ordinary Postgres errors and feed the existing retry → circuit-breaker → JSON-fallback path within bounded time. A new field is used (rather than reusing the 15s `postgres_timeout`) because a TCP-handshake bound is semantically distinct from a query-statement bound; `to_dict()` uses `dataclasses.asdict`, so it auto-flows into audit snapshots / `RunMetadata.config`.

## Verification

```
$ make test
================ 725 passed, 4 deselected, 2 warnings in 9.70s =================
Required test coverage of 92% reached. Total coverage: 92.96%

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
50 files already formatted

$ make lint   # ruff + mypy
uv run ruff check domain_scout/
All checks passed!
uv run mypy domain_scout/ --ignore-missing-imports
Success: no issues found in 50 source files
```

New test `TestPgConnect::test_connect_passes_connect_timeout` patches `psycopg2.connect` and asserts the kwarg is passed with a **non-default** configured value (7), proving config wiring rather than a hardcoded default.

## Self-review

1. Scope is exactly the connection code + config field + one test; no lock churn (`git diff uv.lock` empty), no unrelated edits.
2. The test uses a non-default value (7, not the 10 default) so it fails if the kwarg is ever hardcoded or dropped; it patches the same `domain_scout.sources.ct_logs.psycopg2` module symbol the code calls.
3. New field placement follows the existing `# --- Timeouts (seconds) ---` block ordering and matches the `postgres_timeout` neighbor pattern; no profile-override or serialization wiring needed since `asdict` covers it and `_PROFILES` uses partial overrides.

Closes #165