### PR TITLE
Make required CI checks always report on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # push events diff against the parent commit via local git history;
+          # a depth-1 clone has no parent and the filter would fail -> gated
+          # jobs skip -> counted green. fetch-depth 2 keeps the diff possible.
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,24 +3,43 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Always runs, so lint/typecheck/test always report a status to branch
+  # protection. On docs-only changes they are skipped via `if:`, which GitHub
+  # counts as success for required checks (unlike paths-ignore, which leaves
+  # them stuck at "Expected" — see #176).
+  changes:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # src = any changed file NOT matching the old paths-ignore list
+          predicate-quantifier: 'every'
+          filters: |
+            src:
+              - '!*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.gitignore'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -36,6 +55,8 @@ jobs:
       - run: uv run ruff format --check domain_scout/
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -50,6 +71,8 @@ jobs:
       - run: uv run mypy domain_scout/ --ignore-missing-imports
 
   test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Integration tests hit real crt.sh:
 make test-integration
 ```
 
+## CI notes
+
+Docs-only changes (`*.md`, `docs/**`, `LICENSE`, `.gitignore`) skip the heavy
+CI jobs via a `changes` gate job; the required check names still report, so
+docs-only PRs merge without running lint/typecheck/test.
+
 ## License
 
 MIT


### PR DESCRIPTION
Closes #176

## Problem

Branch protection on `main` requires contexts `lint`, `typecheck`, `test` — the three job ids in `ci.yml`. That workflow had `paths-ignore` (`*.md`, `docs/**`, `LICENSE`, `.gitignore`) on both triggers, so docs-only PRs never spawn those checks and sit at **Expected** forever (#175 needed an `--admin` override).

## Fix: option (a) — always-run workflow with a `changes` detection job

Dropped `paths-ignore`; added a `changes` job using `dorny/paths-filter@v3` with `predicate-quantifier: 'every'` and the old ignore list negated (`!*.md`, `!docs/**`, `!LICENSE`, `!.gitignore`) — `src` is true iff any changed file is *not* on the old ignore list, the exact inverse of `paths-ignore` semantics. `lint`/`typecheck`/`test` gain `needs: changes` + `if: needs.changes.outputs.src == 'true'`. On docs-only changes they are **skipped**, and GitHub counts a job skipped via `if:` as satisfying required status checks (per docs: ["Handling skipped but required checks"](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)) — unlike a path-filtered-away workflow, which stays Pending/Expected.

**Why not option (b) (mirror stub workflow reporting the same check names on the ignored paths):**
- Mixed PRs (docs + code) would trigger *both* workflows — `paths-ignore` skips only when **all** files are ignored, `paths` fires when **any** file matches — producing duplicate check names where the instant stub success can mask/race a real failure. Same subtle-branch-protection-semantics class as the reusable-workflow check-rename gotcha.
- It adds a third and fourth copy of the path list that must stay an exact inverse forever (drift hazard). Option (a) collapses the list to one place.

**Check names preserved exactly:** job ids `lint`, `typecheck`, `test` are untouched and have no `name:` overrides — required contexts still match. The new `changes` context is *not* required.

**Permissions:** added explicit `permissions: contents: read, pull-requests: read` — dorny/paths-filter lists PR files via the API on `pull_request` events; everything else in this workflow only needs checkout. Net effect is more restrictive than the implicit default. No PAT anywhere.

## Known tradeoff (fail-open edge)

If the `changes` job itself *fails* (e.g. action outage), the three gated jobs are skipped (implicit `success()` in job-level `if:`) and would count as satisfied — mergeable with no CI, with only a red non-required `changes` check as a visual signal. Optional hardening once this proves out: add `changes` to the required contexts (it always runs, so it can never wedge at Expected):
```
gh api -X POST repos/minghsuy/domain-scout/branches/main/protection/required_status_checks/contexts -f "contexts[]=changes"
```

## Verification

Verified locally:
- `actionlint` (via `rhysd/actionlint:latest` docker image) — clean on the new `ci.yml`.
- YAML parse + structural asserts (PyYAML): job set is `[changes, lint, typecheck, test]`, no `name:` overrides, all three gated on `needs.changes.outputs.src == 'true'`, no `paths-ignore` remains.
- dorny/paths-filter README confirms `predicate-quantifier: 'every'` + `!` negation semantics (output true iff **any** changed file matches **all** rules).

**Full verification requires a live docs-only PR after this merges.** Probe PR: #181. Note the probe cannot go green **before** this PR merges — `pull_request` runs use the workflow from the merge ref, so pre-merge it exercises the old `paths-ignore` file and demonstrates the bug (checks stuck at Expected). After merging this PR, re-trigger the probe (empty commit push or close/reopen), then `lint`/`typecheck`/`test` should report **skipped** and the probe become mergeable. Do not merge the probe — it exists only as the #176 verification vehicle.

## Self-review (cold re-read of final diff)

1. **Anything unnecessarily clever or leftover from drafting?** No dead keys, debug steps, or drafting artifacts. The two comments are load-bearing (they explain the non-obvious skipped-counts-as-success mechanism and that the filter is the negated old ignore list). The `changes` job's `actions/checkout` step is required — dorny uses git diff for `push` events (API only covers `pull_request`).
2. **Are the claims above verifiable as stated?** actionlint exit 0 and the PyYAML assert script both ran against this exact commit (c4a8f16); the filter semantics claim quotes the dorny README outputs section verbatim. The one claim I *cannot* verify pre-merge is the end-to-end branch-protection behavior — stated explicitly above, probe PR attached.
3. **Does this match the file's existing patterns?** Third-party action pinned by major tag (`@v3`) like `astral-sh/setup-uv@v4` / `actions/checkout@v4`; every job declares `timeout-minutes` (5 for the API-call job, 15 like the others elsewhere); explicit `permissions:` block mirrors `docs.yml`. `release.yml` defines its own same-named jobs but is tag-triggered only — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
