### PR TITLE
[#176 verification probe — DO NOT MERGE] docs: link License section to LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ make test-integration
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
**This PR is the live verification probe for #176 / PR #180. Do not merge.**

One-line docs-only change (README License section links to the LICENSE file) — exercises exactly the path class (`*.md`) that blocked #175.

Expected behavior:
- **Before #180 merges:** `lint`/`typecheck`/`test` sit at **Expected** and this PR is blocked — this *demonstrates* the #176 bug (pull_request runs use the workflow from the merge ref, which still has `paths-ignore` until #180 lands).
- **After #180 merges:** re-trigger this PR (empty commit push or close/reopen — a base-branch merge does not re-run pull_request workflows), then the `changes` job should run, `lint`/`typecheck`/`test` should report **skipped**, and the PR should show as mergeable without any admin override. That's the pass condition.

Once verified, close this PR (or merge it if the one-liner is wanted — owner's call, but its job is done either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)