### PR TITLE
CI: publish coverage reports and align setup-uv to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
         if: always()
         run: |
           if [ -f coverage.xml ]; then
-            python3 -c "import xml.etree.ElementTree as ET; r = float(ET.parse('coverage.xml').getroot().get('line-rate')); print(f'Total coverage: {r:.2%}')" >> "$GITHUB_STEP_SUMMARY"
+            # best-effort: a malformed/truncated XML must never fail the job
+            python3 -c "import xml.etree.ElementTree as ET; r = float(ET.parse('coverage.xml').getroot().get('line-rate')); print(f'Total coverage: {r:.2%}')" >> "$GITHUB_STEP_SUMMARY" || true
           fi
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: actions/setup-python@v5
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: actions/setup-python@v5
@@ -82,11 +82,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run pytest domain_scout/tests -m "not integration" -v
+      - run: uv run pytest domain_scout/tests -m "not integration" -v --cov-report=term --cov-report=xml
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -f coverage.xml ]; then
+            python3 -c "import xml.etree.ElementTree as ET; r = float(ET.parse('coverage.xml').getroot().get('line-rate')); print(f'Total coverage: {r:.2%}')" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
Closes #170

## What

1. **setup-uv aligned to `@v6` everywhere.** Audit found `ci.yml` (3×) and `release.yml` (4×) on `@v4`, `docs.yml` on `@v6`. All 8 references now pin `@v6` (the issue's preferred direction — current major, already proven in this repo by docs.yml). Tag pins match existing house style; no workflow in this repo pins by SHA.
2. **Coverage published from the `test` job** (artifact-only — the issue's "safe default"; no Codecov, no new external dependencies, no new required checks):
   - pytest now passes `--cov-report=term --cov-report=xml` (the `--cov=domain_scout --cov-fail-under=92` gate already lives in `pyproject.toml` `addopts` and is unchanged; `term` is stated explicitly because naming any `--cov-report` suppresses the default terminal table).
   - `coverage.xml` uploaded via `actions/upload-artifact@v4` (same action/major as release.yml's dist upload), gated `if: always()` — pytest-cov writes the XML *before* the fail-under check, so the report is downloadable precisely when the gate fails, which is the pain point in the issue. `if-no-files-found: ignore` keeps runs that die before pytest (e.g. `uv sync` failure) free of noise.
   - One-line total in `$GITHUB_STEP_SUMMARY`, parsed from `coverage.xml` with stdlib only.

## Verification

- Ran the exact new invocation locally via uv: **725 passed, total coverage 92.96%** (second run 92.97% — hypothesis tests wiggle the last digit), `coverage.xml` written, gate passes. Summary step executed verbatim locally: prints `Total coverage: 92.97%`.
- `actionlint` (docker rhysd/actionlint): clean, exit 0. All workflows parse as YAML.
- This PR touches `.github/workflows/*.yml`, which is `src` under the `changes` filter, so lint/typecheck/test all run here and the new steps prove out on this PR's own CI.

## Self-review

1. **Anything unnecessarily clever or leftover from drafting?** First draft's summary line included `(fail-under: 92%)` — a hardcoded duplicate of the pyproject threshold (drift hazard); removed before commit. The remaining python one-liner is stdlib-only XML attribute read, nothing clever.
2. **Are the claims verifiable as stated?** "725 passed, 92.96%" is from running `uv run pytest domain_scout/tests -m "not integration" -v --cov-report=term --cov-report=xml` in a fresh clone (`uv sync --all-groups --all-extras --frozen`), exit 0. actionlint exit code 0 observed. `grep -rn setup-uv .github/workflows/` shows 8 hits, all `@v6` (the issue's acceptance criterion).
3. **Does this match existing patterns?** Job ids (`changes`/`lint`/`typecheck`/`test`), `needs`/`if` gating from #180, and workflow `permissions` are untouched — required-check names preserved. Artifact upload mirrors release.yml's existing `actions/upload-artifact@v4` block style. One noted behavior change: release.yml never set `enable-cache`, and setup-uv v6 enables caching by default on hosted runners where v4 did not — benign (faster installs) and inherent to the version alignment the issue asks for; ci.yml already set `enable-cache: true` explicitly, so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)