### PR TITLE
Add scorer_id/scorer_version to DiscoveredDomain (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `DiscoveredDomain` now carries `scorer_id` and `scorer_version` (schema 1.1,
+  #184): the heuristic ladder stamps `heuristic/<rule-set date>` and the learned
+  scorer stamps `learned_lr/<artifact version>@<training date>`, so a persisted
+  confidence value is no longer ambiguous about which of the two incomparable
+  scorers produced it. Additive and defaulted to `unknown` — pre-1.1 result
+  JSON still validates, and downstream consumers that read `confidence` are
+  unaffected. `domain-scout diff` no longer reports confidence deltas between
+  differing scorer identities (a scorer switch used to surface as hundreds of
+  spurious "confidence changed" entries); it emits a single run-level
+  `scorer_changed` warning instead, while non-confidence changes (`resolves`,
+  `sources`, `rdap_org`) are still reported per domain.
+
 ### Changed
 - The `ct_org_match` source now requires a strict word-bounded org-name match in
   addition to the fuzzy `org_match_threshold`. The fuzzy scorer credited

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,8 @@ class ScoutResult(BaseModel):
 class DiscoveredDomain(BaseModel):
     domain: str                          # e.g. "samsclub.com"
     confidence: float                    # 0.0 to 1.0
+    scorer_id: str                       # scorer that produced confidence: "heuristic" | "learned_lr"
+    scorer_version: str                  # rule-set date or model artifact version, e.g. "v1@2026-03-01"
     sources: list[str]                   # e.g. ["ct_org_match", "ct_san_expansion:walmart.com"]
     evidence: list[EvidenceRecord]       # structured attribution evidence
     cert_org_names: list[str]            # organization names from certificates
@@ -117,7 +119,7 @@ class EvidenceRecord(BaseModel):
 
 ```python
 class RunMetadata(BaseModel):
-    schema_version: str = "1.0"          # output schema version
+    schema_version: str = "1.1"          # output schema version (1.1: scorer_id/scorer_version)
     tool_version: str                    # domain-scout package version
     timestamp: datetime                  # UTC timestamp of the run
     elapsed_seconds: float               # wall-clock duration
@@ -214,9 +216,16 @@ class DeltaSummary(BaseModel):
 
 ```python
 class DeltaWarning(BaseModel):
-    code: str                            # e.g. "seeds_changed", "config_changed"
+    code: str                            # e.g. "seeds_changed", "config_changed", "scorer_changed"
     message: str                         # human-readable explanation
 ```
+
+Confidence deltas are only reported when both scans used the same scorer
+identity (`scorer_id` + `scorer_version`). When the scorer differs — e.g. a
+switch from the heuristic ladder to the learned model, or a retrained artifact
+— per-domain confidence changes are suppressed as incomparable and a single
+run-level `scorer_changed` warning is emitted instead. Non-confidence changes
+(`resolves`, `sources`, `rdap_org`) are still reported per domain.
 
 ## REST API
 

--- a/domain_scout/delta.py
+++ b/domain_scout/delta.py
@@ -15,6 +15,10 @@ from domain_scout.models import (
 _CONFIDENCE_EPSILON = 0.02
 
 
+def _scorer_identity(d: DiscoveredDomain) -> tuple[str, str]:
+    return (d.scorer_id, d.scorer_version)
+
+
 def compute_delta(baseline: ScoutResult, current: ScoutResult) -> DeltaReport:
     """Compare two scan results and produce a delta report."""
     warnings = _check_warnings(baseline, current)
@@ -29,8 +33,14 @@ def compute_delta(baseline: ScoutResult, current: ScoutResult) -> DeltaReport:
     added = [current_map[k] for k in added_keys]
     removed = [baseline_map[k] for k in removed_keys]
 
+    scorer_transitions: dict[tuple[tuple[str, str], tuple[str, str]], int] = {}
     changed: list[ChangedDomain] = []
     for key in common_keys:
+        old_identity = _scorer_identity(baseline_map[key])
+        new_identity = _scorer_identity(current_map[key])
+        if old_identity != new_identity:
+            pair = (old_identity, new_identity)
+            scorer_transitions[pair] = scorer_transitions.get(pair, 0) + 1
         changes = _diff_domain(baseline_map[key], current_map[key])
         if changes:
             changed.append(
@@ -41,6 +51,23 @@ def compute_delta(baseline: ScoutResult, current: ScoutResult) -> DeltaReport:
                     current_confidence=current_map[key].confidence,
                 )
             )
+
+    if scorer_transitions:
+        total = sum(scorer_transitions.values())
+        detail = ", ".join(
+            f"{'/'.join(old_id)} -> {'/'.join(new_id)} ({count})"
+            for (old_id, new_id), count in sorted(scorer_transitions.items())
+        )
+        warnings.append(
+            DeltaWarning(
+                code="scorer_changed",
+                message=(
+                    f"Scorer identity differs on {total} of {len(common_keys)} common "
+                    f"domains ({detail}); confidence deltas on those domains are "
+                    f"suppressed as incomparable"
+                ),
+            )
+        )
 
     summary = DeltaSummary(
         added=len(added),
@@ -63,10 +90,20 @@ def compute_delta(baseline: ScoutResult, current: ScoutResult) -> DeltaReport:
 
 
 def _diff_domain(old: DiscoveredDomain, new: DiscoveredDomain) -> list[DomainChange]:
-    """Return field-level changes between two versions of the same domain."""
+    """Return field-level changes between two versions of the same domain.
+
+    Confidence is only compared when both values come from the same scorer
+    identity — a heuristic ladder score and a learned calibrated probability
+    (or two differently-versioned scorers) are incomparable, and diffing them
+    would report a scorer switch as hundreds of real-world changes (#184).
+    compute_delta emits a run-level "scorer_changed" warning instead.
+    """
     changes: list[DomainChange] = []
 
-    if abs(old.confidence - new.confidence) >= _CONFIDENCE_EPSILON:
+    if (
+        _scorer_identity(old) == _scorer_identity(new)
+        and abs(old.confidence - new.confidence) >= _CONFIDENCE_EPSILON
+    ):
         changes.append(DomainChange(field="confidence", old=old.confidence, new=new.confidence))
 
     if old.resolves != new.resolves:

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -43,6 +43,12 @@ class DiscoveredDomain(BaseModel):
 
     domain: str
     confidence: float = Field(ge=0.0, le=1.0)
+    # Identity of the scorer that produced `confidence`. Heuristic ladder scores and
+    # learned calibrated probabilities are NOT comparable — consumers must not diff
+    # confidence values across differing scorer identities (see delta._diff_domain).
+    # Defaults to "unknown" so results persisted before schema 1.1 still validate.
+    scorer_id: str = "unknown"
+    scorer_version: str = "unknown"
     sources: list[str] = Field(default_factory=list)
     evidence: list[EvidenceRecord] = Field(default_factory=list)
     cert_org_names: list[str] = Field(default_factory=list)
@@ -57,7 +63,8 @@ class DiscoveredDomain(BaseModel):
 class RunMetadata(BaseModel):
     """Metadata about a domain-scout run for audit and reproducibility."""
 
-    schema_version: str = "1.0"
+    # 1.1: added DiscoveredDomain.scorer_id / scorer_version (additive, issue #184)
+    schema_version: str = "1.1"
     tool_version: str
     timestamp: datetime
     elapsed_seconds: float

--- a/domain_scout/scorer/__init__.py
+++ b/domain_scout/scorer/__init__.py
@@ -11,6 +11,8 @@ import math
 from importlib import resources
 from typing import Any
 
+SCORER_ID = "learned_lr"
+
 
 def _load_model() -> dict[str, Any]:
     """Load the default model artifact shipped with the package."""
@@ -130,6 +132,16 @@ def _isotonic_interpolate(x: float, x_vals: list[float], y_vals: list[float]) ->
 # ---------------------------------------------------------------------------
 # Public scoring API
 # ---------------------------------------------------------------------------
+
+
+def scorer_version() -> str:
+    """Identity of the loaded model artifact: "<version>@<training_date>".
+
+    The artifact version alone ("v1") is not enough — a retrain keeps the version
+    but shifts every probability, so the training date is the discriminator.
+    """
+    model = _get_model()
+    return f"{model['version']}@{model['training_date']}"
 
 
 def score_confidence(

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -75,6 +75,19 @@ _SIGNAL_MAP: dict[str, tuple[str, float]] = {
 }
 
 
+# Identity of the built-in heuristic ladder (Scout._score_confidence).
+# The version is the date of the last commit that changed heuristic scoring
+# semantics — ladder base values, corroboration adjustments, sibling penalty,
+# or the meaning of a source signal feeding the ladder (2026-07-03 = strict
+# word-bounded ct_org_match gate, #178). Bump this date whenever any of those
+# change, so delta reports can tell a rule change from real-world change.
+# Note: the post-scoring _infra_boost (+0.05) applies to BOTH scorer paths and
+# is versioned by neither this constant nor the model artifact — if its formula
+# changes, learned-scored domains will report it as a confidence change.
+HEURISTIC_SCORER_ID = "heuristic"
+HEURISTIC_SCORER_VERSION = "2026-07-03"
+
+
 # Source tags that represent org-name-matched evidence (not SAN expansion).
 _ORG_MATCH_TAGS = frozenset({"ct_org_match", "ct_subsidiary_match", "ct_gleif_subsidiary"})
 
@@ -1083,7 +1096,12 @@ class Scout:
     ) -> float:
         # Learned scorer path (opt-in via config)
         if self.config.use_learned_scorer and domain and accum.cert_org_names:
+            from domain_scout.scorer import SCORER_ID as _LEARNED_SCORER_ID
             from domain_scout.scorer import score_confidence as _learned_score
+            from domain_scout.scorer import scorer_version as _learned_scorer_version
+
+            accum.scorer_id = _LEARNED_SCORER_ID
+            accum.scorer_version = _learned_scorer_version()
 
             best_sim = max(
                 (org_name_similarity(cert_org, company_name) for cert_org in accum.cert_org_names),
@@ -1118,6 +1136,9 @@ class Scout:
             )
 
         # Heuristic scorer (default)
+        accum.scorer_id = HEURISTIC_SCORER_ID
+        accum.scorer_version = HEURISTIC_SCORER_VERSION
+
         # Phase 1: base score from source type
         score = 0.0
 
@@ -1442,6 +1463,8 @@ class Scout:
                 DiscoveredDomain(
                     domain=domain,
                     confidence=accum.confidence,
+                    scorer_id=accum.scorer_id,
+                    scorer_version=accum.scorer_version,
                     sources=sorted(accum.sources),
                     evidence=deduped,
                     cert_org_names=sorted(accum.cert_org_names),
@@ -1534,6 +1557,8 @@ class _DomainAccum:
         "resolves",
         "rdap_org",
         "confidence",
+        "scorer_id",
+        "scorer_version",
     )
 
     def __init__(self) -> None:
@@ -1545,6 +1570,9 @@ class _DomainAccum:
         self.resolves: bool = False
         self.rdap_org: str | None = None
         self.confidence: float = 0.0
+        # Stamped by Scout._score_confidence; "unknown" until scored.
+        self.scorer_id: str = "unknown"
+        self.scorer_version: str = "unknown"
 
     def merge(self, other: _DomainAccum) -> None:
         self.sources |= other.sources

--- a/domain_scout/tests/test_delta.py
+++ b/domain_scout/tests/test_delta.py
@@ -34,6 +34,8 @@ def _make_domain(
     resolves: bool = True,
     sources: list[str] | None = None,
     rdap_org: str | None = None,
+    scorer_id: str = "unknown",
+    scorer_version: str = "unknown",
 ) -> DiscoveredDomain:
     return DiscoveredDomain(
         domain=domain,
@@ -41,6 +43,8 @@ def _make_domain(
         resolves=resolves,
         sources=sources or ["ct_san"],
         rdap_org=rdap_org,
+        scorer_id=scorer_id,
+        scorer_version=scorer_version,
     )
 
 
@@ -289,6 +293,80 @@ class TestDeltaWarnings:
         )
         codes = [w.code for w in result.warnings]
         assert "schema_version_mismatch" in codes
+
+
+# --- TestScorerIdentityDelta (issue #184) ---
+
+
+class TestScorerIdentityDelta:
+    """A scorer switch must not read as hundreds of real-world confidence changes."""
+
+    def test_scorer_switch_suppresses_confidence_delta(self) -> None:
+        old = _make_domain(confidence=0.85, scorer_id="heuristic", scorer_version="2026-07-03")
+        new = _make_domain(confidence=0.62, scorer_id="learned_lr", scorer_version="v1@2026-03-01")
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 0
+        assert report.summary.unchanged == 1
+
+    def test_scorer_version_only_change_also_suppresses(self) -> None:
+        """A retrain (same scorer_id, new version) is just as incomparable."""
+        old = _make_domain(confidence=0.62, scorer_id="learned_lr", scorer_version="v1@2026-03-01")
+        new = _make_domain(confidence=0.44, scorer_id="learned_lr", scorer_version="v2@2026-07-01")
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 0
+
+    def test_scorer_switch_emits_run_level_warning(self) -> None:
+        domains_old = [
+            _make_domain("a.com", 0.85, scorer_id="heuristic", scorer_version="2026-07-03"),
+            _make_domain("b.com", 0.90, scorer_id="heuristic", scorer_version="2026-07-03"),
+        ]
+        domains_new = [
+            _make_domain("a.com", 0.62, scorer_id="learned_lr", scorer_version="v1@2026-03-01"),
+            _make_domain("b.com", 0.71, scorer_id="learned_lr", scorer_version="v1@2026-03-01"),
+        ]
+        report = compute_delta(_make_result(domains_old), _make_result(domains_new))
+        warning = next(w for w in report.warnings if w.code == "scorer_changed")
+        assert "2 of 2 common domains" in warning.message
+        assert "heuristic/2026-07-03 -> learned_lr/v1@2026-03-01 (2)" in warning.message
+        assert "suppressed as incomparable" in warning.message
+
+    def test_same_scorer_still_reports_confidence_delta(self) -> None:
+        old = _make_domain(confidence=0.85, scorer_id="heuristic", scorer_version="2026-07-03")
+        new = _make_domain(confidence=0.62, scorer_id="heuristic", scorer_version="2026-07-03")
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 1
+        assert report.changed[0].changes[0].field == "confidence"
+        assert not any(w.code == "scorer_changed" for w in report.warnings)
+
+    def test_scorer_switch_still_reports_real_world_changes(self) -> None:
+        """Non-confidence changes (resolves, sources, rdap_org) survive the switch."""
+        old = _make_domain(
+            confidence=0.85, resolves=True, scorer_id="heuristic", scorer_version="2026-07-03"
+        )
+        new = _make_domain(
+            confidence=0.62, resolves=False, scorer_id="learned_lr", scorer_version="v1@2026-03-01"
+        )
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 1
+        fields = [c.field for c in report.changed[0].changes]
+        assert fields == ["resolves"]
+
+    def test_unknown_baseline_vs_stamped_current_suppresses(self) -> None:
+        """First diff after upgrading: pre-1.1 baseline vs freshly stamped current."""
+        old = _make_domain(confidence=0.85)  # legacy payload: defaults to unknown/unknown
+        new = _make_domain(confidence=0.62, scorer_id="heuristic", scorer_version="2026-07-03")
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 0
+        warning = next(w for w in report.warnings if w.code == "scorer_changed")
+        assert "unknown/unknown -> heuristic/2026-07-03 (1)" in warning.message
+
+    def test_legacy_unknown_identity_pairs_compare_normally(self) -> None:
+        """Two pre-1.1 results (both default 'unknown') keep the old behavior."""
+        old = _make_domain(confidence=0.85)
+        new = _make_domain(confidence=0.62)
+        report = compute_delta(_make_result([old]), _make_result([new]))
+        assert report.summary.changed == 1
+        assert not any(w.code == "scorer_changed" for w in report.warnings)
 
 
 # --- TestDeltaSerialization ---

--- a/domain_scout/tests/test_evidence.py
+++ b/domain_scout/tests/test_evidence.py
@@ -63,7 +63,8 @@ class TestRunMetadata:
             elapsed_seconds=1.0,
             domains_found=5,
         )
-        assert meta.schema_version == "1.0"
+        # 1.1: DiscoveredDomain gained scorer_id/scorer_version (#184)
+        assert meta.schema_version == "1.1"
 
     def test_config_snapshot(self) -> None:
         cfg = ScoutConfig(total_timeout=120)

--- a/domain_scout/tests/test_invariants.py
+++ b/domain_scout/tests/test_invariants.py
@@ -231,6 +231,70 @@ class TestScoringPriority:
 
 
 # ---------------------------------------------------------------------------
+# 3b. Scorer identity stamping (issue #184: confidence must carry provenance)
+# ---------------------------------------------------------------------------
+
+
+class TestScorerIdentityStamping:
+    """_score_confidence must stamp scorer_id/scorer_version on the accum."""
+
+    @staticmethod
+    def _make_accum(**kwargs: object) -> _DomainAccum:
+        accum = _DomainAccum()
+        for k, v in kwargs.items():
+            setattr(accum, k, v)
+        return accum
+
+    def test_heuristic_path_stamps_identity(self) -> None:
+        from domain_scout.config import ScoutConfig
+        from domain_scout.scout import HEURISTIC_SCORER_ID, HEURISTIC_SCORER_VERSION
+
+        accum = self._make_accum(
+            sources={"ct_org_match"},
+            cert_org_names={"TestCo"},
+            resolves=True,
+        )
+        scout = Scout(config=ScoutConfig())
+        scout._score_confidence(accum, "TestCo", ["test.com"], domain="example.com")
+        assert accum.scorer_id == HEURISTIC_SCORER_ID == "heuristic"
+        assert accum.scorer_version == HEURISTIC_SCORER_VERSION
+
+    def test_learned_path_stamps_identity(self) -> None:
+        from domain_scout.config import ScoutConfig
+        from domain_scout.scorer import SCORER_ID, scorer_version
+
+        accum = self._make_accum(
+            sources={"ct_org_match"},
+            cert_org_names={"TestCo"},
+            resolves=True,
+        )
+        scout = Scout(config=ScoutConfig(use_learned_scorer=True))
+        scout._score_confidence(accum, "TestCo", ["test.com"], domain="example.com")
+        assert accum.scorer_id == SCORER_ID == "learned_lr"
+        assert accum.scorer_version == scorer_version()
+
+    def test_learned_config_without_cert_orgs_falls_back_to_heuristic_identity(self) -> None:
+        """The learned path needs cert_org_names; the fallback must not mislabel."""
+        from domain_scout.config import ScoutConfig
+        from domain_scout.scout import HEURISTIC_SCORER_ID, HEURISTIC_SCORER_VERSION
+
+        accum = self._make_accum(
+            sources={"dns_guess"},
+            cert_org_names=set(),
+            resolves=True,
+        )
+        scout = Scout(config=ScoutConfig(use_learned_scorer=True))
+        scout._score_confidence(accum, "TestCo", ["test.com"], domain="example.com")
+        assert accum.scorer_id == HEURISTIC_SCORER_ID
+        assert accum.scorer_version == HEURISTIC_SCORER_VERSION
+
+    def test_accum_defaults_to_unknown_before_scoring(self) -> None:
+        accum = _DomainAccum()
+        assert accum.scorer_id == "unknown"
+        assert accum.scorer_version == "unknown"
+
+
+# ---------------------------------------------------------------------------
 # 4. Cross-seed boost invariants
 # ---------------------------------------------------------------------------
 

--- a/domain_scout/tests/test_models.py
+++ b/domain_scout/tests/test_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from domain_scout.models import EntityInput
+from domain_scout.models import DiscoveredDomain, EntityInput
 
 
 def test_entity_input_seed_domain_max_length() -> None:
@@ -69,3 +69,30 @@ def test_entity_input_company_name_max_length_still_enforced() -> None:
     with pytest.raises(ValidationError) as exc_info:
         EntityInput(company_name="x" * 201)
     assert "at most 200" in str(exc_info.value)
+
+
+# --- DiscoveredDomain scorer identity (issue #184, schema 1.1) ---
+
+
+def test_discovered_domain_scorer_fields_round_trip() -> None:
+    """scorer_id/scorer_version survive JSON serialization."""
+    d = DiscoveredDomain(
+        domain="example.com",
+        confidence=0.62,
+        scorer_id="learned_lr",
+        scorer_version="v1@2026-03-01",
+    )
+    payload = d.model_dump_json()
+    assert '"scorer_id":"learned_lr"' in payload
+    assert '"scorer_version":"v1@2026-03-01"' in payload
+    restored = DiscoveredDomain.model_validate_json(payload)
+    assert restored.scorer_id == "learned_lr"
+    assert restored.scorer_version == "v1@2026-03-01"
+
+
+def test_discovered_domain_legacy_payload_defaults_to_unknown() -> None:
+    """Pre-1.1 results (no scorer fields) must still validate, as 'unknown'."""
+    legacy = {"domain": "example.com", "confidence": 0.85}
+    d = DiscoveredDomain.model_validate(legacy)
+    assert d.scorer_id == "unknown"
+    assert d.scorer_version == "unknown"

--- a/domain_scout/tests/test_scorer.py
+++ b/domain_scout/tests/test_scorer.py
@@ -25,3 +25,14 @@ from domain_scout.scorer import _clean_name
 )
 def test_clean_name(input_name: str, expected: str) -> None:
     assert _clean_name(input_name) == expected
+
+
+def test_scorer_identity_constants() -> None:
+    """The learned scorer exposes a stable id and an artifact-derived version."""
+    from domain_scout.scorer import SCORER_ID, _get_model, scorer_version
+
+    assert SCORER_ID == "learned_lr"
+    model = _get_model()
+    assert scorer_version() == f"{model['version']}@{model['training_date']}"
+    # Pin the shipped artifact so a silent retrain can't reuse an old identity.
+    assert scorer_version() == "v1@2026-03-01"


### PR DESCRIPTION
Closes #184

## What

`confidence` carried both the heuristic max-ladder score and the learned calibrated probability with no scorer identity — a scorer switch read as hundreds of spurious "confidence changed" deltas, and downstream rows accumulated where 0.85 means different things across time.

- **`DiscoveredDomain.scorer_id` / `scorer_version`** (schema `1.0` → `1.1`), defaulted to `"unknown"` so persisted pre-1.1 result JSON still validates (`cli.py diff` loads old baselines via `model_validate_json`).
- **Heuristic path** stamps `heuristic` / `HEURISTIC_SCORER_VERSION` (`"2026-07-03"` — dated constant introduced next to the ladder; the date is the last commit that changed heuristic scoring semantics, cf60d4f `#178` strict ct_org_match gate, with a derivation comment saying exactly when to bump it).
- **Learned path** stamps `learned_lr` / `v1@2026-03-01` derived from the `logistic_v1.json` artifact (`<version>@<training_date>` — version alone is insufficient because a retrain keeps `v1` but shifts every probability). Stamping is **per-domain**: with `use_learned_scorer=True`, domains lacking `cert_org_names` fall back to the heuristic ladder and are stamped as such.
- **`delta._diff_domain`** only compares confidence within one scorer identity; **`compute_delta`** emits a single run-level `scorer_changed` warning with transition counts (e.g. `heuristic/2026-07-03 -> learned_lr/v1@2026-03-01 (5)`). Non-confidence changes (`resolves`, `sources`, `rdap_org`) still report per domain.

## Design choice: suppress per-domain, annotate at run level

The report has a natural annotation slot — `DeltaReport.warnings` — so the switch is announced there once, with counts. Pure per-domain annotation was rejected because it keeps `summary.changed` ≈ all common domains, which is exactly the noise #184 complains about; the values are incomparable, so any per-domain confidence delta across identities is meaningless, not merely suspicious. Trade-off accepted: a genuine real-world shift that coincides with a scorer switch is blinded on the confidence axis for that one transition scan (the warning makes the blind spot explicit).

## Downstream compatibility (nightly discover → insurance-market-db)

Verified the consumer directly (`~/insurance-market-db/src/scanner.py`):
- `batch_scan` stores `result.model_dump(mode="json")` as an opaque `result_json` blob and extracts only `domain`, `confidence`, `resolves`, `evidence[].source_type` into `EntityDomain` — additive fields flow into the blob harmlessly.
- `load_existing_results` reads raw dicts with `.get()` — additive fields ignored.
- Nothing downstream validates `schema_version` (only `delta.py` compares it between two scans, emitting the pre-existing informational warning).

New rows now persist scorer identity inside `result_json`, which is the durable fix the issue asks for.

## Verification (real output)

Exact CI invocation (`uv run pytest domain_scout/tests -m "not integration" -v --cov-report=term --cov-report=xml`):

```
Required test coverage of 92% reached. Total coverage: 93.78%
================ 739 passed, 4 deselected, 2 warnings in 7.73s =================
```

(725 baseline before this branch; +14 new tests. The 2 warnings are pre-existing `RuntimeWarning`s in `test_subsidiary.py`.)

```
$ uv run ruff check .          → All checks passed!
$ uv run ruff format --check . → 50 files already formatted
```

End-to-end (drove the actual `diff` CLI on fixture files simulating a heuristic→learned switch across 5 domains):

```
Warning [scorer_changed]: Scorer identity differs on 5 of 5 common domains
  (heuristic/2026-07-03 -> learned_lr/v1@2026-03-01 (5)); confidence deltas on
  those domains are suppressed as incomparable
Summary: 0 added, 0 removed, 0 changed, 5 unchanged
```

## Adversarial self-review

An adversarial reviewer agent ran on the final diff (independently reproduced test count, coverage, ruff, mypy, and the unknown→stamped transition). Findings and dispositions:

**(a) Anything unnecessarily clever or leftover from drafting?** No dead code, debug prints, or draft aliases found. The `SCORER_ID as _LEARNED_SCORER_ID` lazy-import alias mirrors the pre-existing `score_confidence as _learned_score` idiom at the same site. One reviewer finding fixed pre-push: the `HEURISTIC_SCORER_VERSION` derivation comment over-claimed coverage of `_infra_boost` (which applies post-scoring to *both* paths and is versioned by neither constant) — comment corrected to state that explicitly.

**(b) Are the PR-body claims verifiable as stated?** Yes — every number above is from commands run on this exact tree: 739/739 with the exact CI invocation (coverage flags included), coverage 93.78% ≥ 92 from the same run's output, ruff check AND format --check both clean. The reviewer independently reproduced 738/93.76% pre-nit-fix and I re-ran after the two nit fixes (739/93.78%). `HEURISTIC_SCORER_VERSION = "2026-07-03"` was cross-checked against `git log` (cf60d4f is the last scoring-semantics change). No workflow files touched, so actionlint is N/A.

**(c) Does this match the file's existing patterns?** Yes — the `scorer_changed` warning follows `delta.py`'s existing `DeltaWarning` message style and is appended in the same `warnings` flow as `schema_version_mismatch`; `_DomainAccum` gains slots in the established `__slots__` + typed-`__init__` pattern; test placement follows each file's conventions (`test_invariants.py` section "3b." between "3." and "4.", `test_delta.py` extends the `_make_domain` helper with defaulted params so all 30 pre-existing delta tests are untouched); the schema bump is pinned where it was already pinned (`test_evidence.py`).

**(d) Design Gate #1.** This implements Gate #1 — de-overloading the confidence field. The float stops being a context-free number: every persisted confidence now carries the identity of the ruler that measured it, which is the precondition for any scorer evolution (retrains, ladder changes, heuristic→learned migration) without corrupting longitudinal comparisons.

Intentionally skipped (reviewer-classified nits): `scorer_id` stays `str` rather than `Literal`/enum — only two producers exist, both pinned by tests, and a `Literal` would make third-party scorers a breaking change; the simultaneous `schema_version_mismatch` + `scorer_changed` warnings on a pre-1.1 comparison are redundant but each is independently true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4