### PR TITLE
Gate the learned-scorer artifact on its own metrics; eval runs both scorer paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The learned-scorer artifact's own persisted metrics are now consumed at load
+  time (#183). An acceptance gate skips the isotonic calibration layer when the
+  artifact reports `lr_calibrated_ece > lr_ece` — true for the shipped v1
+  artifact (0.2182 vs 0.0072), so raw LR probabilities are used and
+  `scorer_version()` stamps a `+uncal` suffix; a future artifact with good
+  calibration gets the layer back automatically. The artifact schema gains
+  `inference_unavailable_features` declaring features the model uses but
+  inference zero-fills (`org_matches_different_entity`, coefficient +0.204 —
+  confidence biased low where that signal would fire); the loader warns once at
+  load, and rejects features it can't compute at all. The eval harness now runs
+  both scorer paths: `make eval` reports a heuristic leg (recorded ranking) and
+  a learned leg (persisted evidence re-scored through the model — an
+  approximation of a live learned run, see `eval._learned_ranked_domains`), so
+  the learned scorer is exercised before `use_learned_scorer` ever flips on.
 - `DiscoveredDomain` now carries `scorer_id` and `scorer_version` (schema 1.1,
   #184): the heuristic ladder stamps `heuristic/<rule-set date>` and the learned
   scorer stamps `learned_lr/<artifact version>@<training date>`, so a persisted

--- a/domain_scout/eval.py
+++ b/domain_scout/eval.py
@@ -67,10 +67,20 @@ class EntityEvalResult(BaseModel):
 
 
 class EvalReport(BaseModel):
-    """Complete evaluation report across all entities."""
+    """Complete evaluation report across all entities.
+
+    ``entities`` carries the heuristic leg (ranking as recorded in the
+    ScoutResult). ``learned_entities`` carries the learned-scorer leg: the
+    same results re-scored and re-ranked through the learned model, so
+    ``make eval`` exercises both scorer paths pre-ship (issue #183).
+    """
 
     mode: str
     entities: list[EntityEvalResult]
+    learned_entities: list[EntityEvalResult] = Field(default_factory=list)
+    # Identity of the learned scorer that produced learned_entities,
+    # e.g. "learned_lr/v1@2026-03-01+uncal" (None if the leg didn't run).
+    learned_scorer: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +185,99 @@ def load_ground_truth(path: Path | None = None) -> list[GroundTruthEntry]:
 
 
 # ---------------------------------------------------------------------------
+# Per-entity evaluation (shared by both scorer legs)
+# ---------------------------------------------------------------------------
+
+
+def _entity_result(
+    gt: GroundTruthEntry,
+    ranked: list[str],
+    k_values: tuple[int, ...],
+) -> EntityEvalResult:
+    """Build an EntityEvalResult for one entity from a ranked domain list."""
+    owned = set(gt.owned_domains)
+    not_owned_set = set(gt.not_owned)
+
+    return EntityEvalResult(
+        label_id=gt.label_id,
+        company_name=gt.company_name,
+        seeds=gt.seeds,
+        discovered_count=len(ranked),
+        owned_count=len(owned),
+        not_owned_count=len(not_owned_set),
+        metrics=compute_metrics(ranked, owned, not_owned_set, k_values),
+        false_positive_domains=collect_false_positives(ranked, not_owned_set),
+    )
+
+
+def _learned_ranked_domains(scout_result: ScoutResult) -> list[str]:
+    """Re-rank a ScoutResult's domains with the learned scorer.
+
+    Mirrors the gating in ``Scout._score_confidence``: the learned path fires
+    only for domains with cert org evidence; every other domain keeps its
+    recorded (heuristic) confidence — the same mixed ranking production
+    produces with ``use_learned_scorer=True``.
+
+    This is an approximation, not a bit-exact replay of a live learned run.
+    Production scores from the pre-output ``_DomainAccum`` state; here only
+    the persisted ``DiscoveredDomain`` is available, which differs in three
+    ways: (1) the post-scoring ``_infra_boost`` +0.05 addend is not
+    re-applied; (2) ``sources`` may contain the ``shared_infra`` tag that
+    ``_infra_boost`` added *after* production scored (flipping the
+    ``has_shared_infra`` feature); (3) ``evidence`` has been through
+    ``_dedup_evidence``, so ``evidence_count``/``unique_cert_count`` can be
+    lower than what production saw. Good enough to exercise the learned path
+    and compare rankings pre-ship; not a substitute for a live
+    ``use_learned_scorer=True`` eval.
+    """
+    from domain_scout.matching.entity_match import org_name_similarity
+    from domain_scout.scorer import score_confidence
+
+    company = scout_result.entity.company_name
+    scored: list[tuple[float, str]] = []
+    for d in scout_result.domains:
+        if d.domain and d.cert_org_names:
+            best_sim = max(
+                (org_name_similarity(org, company) for org in d.cert_org_names),
+                default=0.0,
+            )
+            cert_ids = {ev.cert_id for ev in d.evidence if ev.cert_id is not None}
+            rdap_sim = max(
+                (
+                    ev.similarity_score
+                    for ev in d.evidence
+                    if ev.source_type == "rdap_registrant_match" and ev.similarity_score is not None
+                ),
+                default=0.0,
+            )
+            confidence = score_confidence(
+                domain=d.domain,
+                company_name=company,
+                best_similarity=best_sim,
+                sources=set(d.sources),
+                cert_org_names=set(d.cert_org_names),
+                resolves=d.resolves,
+                evidence_count=len(d.evidence),
+                unique_cert_count=len(cert_ids),
+                rdap_similarity=rdap_sim,
+            )
+        else:
+            confidence = d.confidence
+        scored.append((confidence, d.domain))
+
+    # Stable sort: ties keep their recorded relative order.
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [domain for _, domain in scored]
+
+
+def _learned_scorer_identity() -> str:
+    """Identity string for the learned leg, e.g. "learned_lr/v1@2026-03-01+uncal"."""
+    from domain_scout.scorer import SCORER_ID, scorer_version
+
+    return f"{SCORER_ID}/{scorer_version()}"
+
+
+# ---------------------------------------------------------------------------
 # Baseline evaluation
 # ---------------------------------------------------------------------------
 
@@ -184,9 +287,14 @@ def evaluate_baseline(
     baselines_dir: Path | None = None,
     k_values: tuple[int, ...] = _DEFAULT_K_VALUES,
 ) -> EvalReport:
-    """Evaluate pre-recorded baseline JSON files against ground truth."""
+    """Evaluate pre-recorded baseline JSON files against ground truth.
+
+    Runs both scorer legs: the recorded (heuristic) ranking and a learned
+    re-scoring of the same evidence.
+    """
     bdir = baselines_dir or _BASELINES_DIR
     results: list[EntityEvalResult] = []
+    learned_results: list[EntityEvalResult] = []
 
     for gt in ground_truth:
         baseline_path = bdir / f"{gt.label_id}.json"
@@ -197,28 +305,17 @@ def evaluate_baseline(
         with open(baseline_path) as f:
             scout_result = ScoutResult.model_validate_json(f.read())
 
-        # Extract ranked domain list (already sorted by confidence desc in ScoutResult)
+        # Ranked domain list (already sorted by confidence desc in ScoutResult)
         ranked = [d.domain for d in scout_result.domains]
-        owned = set(gt.owned_domains)
-        not_owned_set = set(gt.not_owned)
+        results.append(_entity_result(gt, ranked, k_values))
+        learned_results.append(_entity_result(gt, _learned_ranked_domains(scout_result), k_values))
 
-        metrics = compute_metrics(ranked, owned, not_owned_set, k_values)
-        fps = collect_false_positives(ranked, not_owned_set)
-
-        results.append(
-            EntityEvalResult(
-                label_id=gt.label_id,
-                company_name=gt.company_name,
-                seeds=gt.seeds,
-                discovered_count=len(ranked),
-                owned_count=len(owned),
-                not_owned_count=len(not_owned_set),
-                metrics=metrics,
-                false_positive_domains=fps,
-            )
-        )
-
-    return EvalReport(mode="baseline", entities=results)
+    return EvalReport(
+        mode="baseline",
+        entities=results,
+        learned_entities=learned_results,
+        learned_scorer=_learned_scorer_identity() if learned_results else None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -230,12 +327,17 @@ async def evaluate_live(
     ground_truth: list[GroundTruthEntry],
     k_values: tuple[int, ...] = _DEFAULT_K_VALUES,
 ) -> EvalReport:
-    """Run Scout.discover_async() for each entity and evaluate against ground truth."""
+    """Run Scout.discover_async() for each entity and evaluate against ground truth.
+
+    Discovery runs once per entity; both scorer legs are computed from the
+    same ScoutResult (the learned leg re-scores the collected evidence).
+    """
     from domain_scout.models import EntityInput
     from domain_scout.scout import Scout
 
     scout = Scout()
     results: list[EntityEvalResult] = []
+    learned_results: list[EntityEvalResult] = []
 
     for gt in ground_truth:
         entity = EntityInput(
@@ -245,31 +347,46 @@ async def evaluate_live(
         scout_result = await scout.discover_async(entity)
 
         ranked = [d.domain for d in scout_result.domains]
-        owned = set(gt.owned_domains)
-        not_owned_set = set(gt.not_owned)
+        results.append(_entity_result(gt, ranked, k_values))
+        learned_results.append(_entity_result(gt, _learned_ranked_domains(scout_result), k_values))
 
-        metrics = compute_metrics(ranked, owned, not_owned_set, k_values)
-        fps = collect_false_positives(ranked, not_owned_set)
-
-        results.append(
-            EntityEvalResult(
-                label_id=gt.label_id,
-                company_name=gt.company_name,
-                seeds=gt.seeds,
-                discovered_count=len(ranked),
-                owned_count=len(owned),
-                not_owned_count=len(not_owned_set),
-                metrics=metrics,
-                false_positive_domains=fps,
-            )
-        )
-
-    return EvalReport(mode="live", entities=results)
+    return EvalReport(
+        mode="live",
+        entities=results,
+        learned_entities=learned_results,
+        learned_scorer=_learned_scorer_identity() if learned_results else None,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Output formatting
 # ---------------------------------------------------------------------------
+
+
+def _format_entity(entity: EntityEvalResult, lines: list[str]) -> None:
+    """Append one entity's metrics block to the output lines."""
+    seeds_str = ", ".join(entity.seeds)
+    lines.append("")
+    lines.append(f"{entity.label_id} ({entity.company_name}, seeds={seeds_str})")
+    lines.append(
+        f"  Discovered: {entity.discovered_count} | "
+        f"Ground truth: {entity.owned_count} owned, "
+        f"{entity.not_owned_count} not-owned"
+    )
+
+    # Table header
+    lines.append(f"  {'k':>5}  {'Precision':>9}  {'Found':>9}  {'FPs':>3}  {'NDCG':>5}")
+    lines.append(f"  {'─' * 5}  {'─' * 9}  {'─' * 9}  {'─' * 3}  {'─' * 5}")
+
+    for m in entity.metrics:
+        found_str = f"{m.hits}/{entity.owned_count}"
+        lines.append(
+            f"  {m.k:>5}  {m.precision:>9.3f}  {found_str:>9}  {m.false_positives:>3}  "
+            f"{m.ndcg:>5.3f}"
+        )
+
+    if entity.false_positive_domains:
+        lines.append(f"  FP domains (all ranks): {', '.join(entity.false_positive_domains)}")
 
 
 def format_table(report: EvalReport) -> str:
@@ -279,28 +396,14 @@ def format_table(report: EvalReport) -> str:
     lines.append("=" * 55)
 
     for entity in report.entities:
-        seeds_str = ", ".join(entity.seeds)
+        _format_entity(entity, lines)
+
+    if report.learned_entities:
         lines.append("")
-        lines.append(f"{entity.label_id} ({entity.company_name}, seeds={seeds_str})")
-        lines.append(
-            f"  Discovered: {entity.discovered_count} | "
-            f"Ground truth: {entity.owned_count} owned, "
-            f"{entity.not_owned_count} not-owned"
-        )
-
-        # Table header
-        lines.append(f"  {'k':>5}  {'Precision':>9}  {'Found':>9}  {'FPs':>3}  {'NDCG':>5}")
-        lines.append(f"  {'─' * 5}  {'─' * 9}  {'─' * 9}  {'─' * 3}  {'─' * 5}")
-
-        for m in entity.metrics:
-            found_str = f"{m.hits}/{entity.owned_count}"
-            lines.append(
-                f"  {m.k:>5}  {m.precision:>9.3f}  {found_str:>9}  {m.false_positives:>3}  "
-                f"{m.ndcg:>5.3f}"
-            )
-
-        if entity.false_positive_domains:
-            lines.append(f"  FP domains (all ranks): {', '.join(entity.false_positive_domains)}")
+        lines.append(f"Learned scorer leg ({report.learned_scorer})")
+        lines.append("=" * 55)
+        for entity in report.learned_entities:
+            _format_entity(entity, lines)
 
     lines.append("")
     return "\n".join(lines)

--- a/domain_scout/scorer/__init__.py
+++ b/domain_scout/scorer/__init__.py
@@ -1,7 +1,11 @@
 """Learned confidence scorer for domain-entity attribution.
 
 Loads a logistic regression model from a JSON artifact and produces
-calibrated probabilities from domain evidence features.
+probabilities from domain evidence features. The artifact's own persisted
+metrics are consumed at load time (issue #183): the isotonic calibration
+layer is only applied when the artifact's metadata says it improves ECE,
+and features the artifact uses but inference cannot supply are surfaced
+with their bias direction.
 """
 
 from __future__ import annotations
@@ -11,7 +15,39 @@ import math
 from importlib import resources
 from typing import Any
 
+import structlog
+
+log = structlog.get_logger()
+
 SCORER_ID = "learned_lr"
+
+# Features score_confidence derives from real inference-time evidence.
+_SUPPLIED_FEATURES = frozenset(
+    {
+        "best_similarity",
+        "source_count",
+        "domain_has_company_token",
+        "has_shared_infra",
+        "has_dns_guess",
+        "tld_is_country",
+        "entity_name_in_org",
+        "evidence_density",
+        "resolves",
+        "domain_length",
+        "rdap_similarity",
+    }
+)
+
+# Train-time-only features: score_confidence zero-fills these because the
+# underlying data is not available at inference (see the raw dict below).
+_ZERO_FILLED_FEATURES = frozenset(
+    {
+        "org_matches_different_entity",  # requires S&P 500 entity data
+        "same_asn_as_anchor",  # requires DNS+ASN lookup
+        "asn_is_cdn",  # requires DNS+ASN lookup
+        "shares_nameserver",  # requires NS lookup
+    }
+)
 
 
 def _load_model() -> dict[str, Any]:
@@ -21,13 +57,86 @@ def _load_model() -> dict[str, Any]:
     return result
 
 
+def _validate_artifact(model: dict[str, Any]) -> dict[str, Any]:
+    """Inference-time acceptance gate: consume the artifact's own metadata.
+
+    Called once at load (the result is cached in ``_MODEL``), so every
+    warning here fires once per process, not per scored domain.
+
+    Two contracts are enforced:
+
+    1. Feature availability — every feature the model uses must either be
+       genuinely computable at inference (``_SUPPLIED_FEATURES``) or a known
+       zero-filled placeholder (``_ZERO_FILLED_FEATURES``). Zero-filled
+       features should be declared by the artifact in
+       ``inference_unavailable_features``; declared or not, the constant
+       train/serve bias is logged with its direction.
+
+    2. Calibration acceptance — the calibration layer is applied only when
+       the artifact's own metrics say it helps (``lr_calibrated_ece <=
+       lr_ece``). A future artifact with good calibration automatically gets
+       the layer back; nothing is hardcoded to this artifact.
+    """
+    features: list[str] = model["features"]
+
+    # -- Feature-availability contract --------------------------------------
+    declared_unavailable = set(model.get("inference_unavailable_features", []))
+    for i, fname in enumerate(features):
+        if fname in _SUPPLIED_FEATURES:
+            continue
+        if fname not in _ZERO_FILLED_FEATURES:
+            raise ValueError(
+                f"model artifact uses feature {fname!r} which inference cannot"
+                " compute; add it to score_confidence or retrain without it"
+            )
+        coef = float(model["coefficients"][fname])
+        mean = float(model["scaler"]["mean"][i])
+        scale = float(model["scaler"]["scale"][i])
+        bias_direction = "low" if coef > 0 else "high"
+        event = (
+            "scorer_feature_zero_filled"
+            if fname in declared_unavailable
+            else "scorer_feature_availability_undeclared"
+        )
+        log.warning(
+            event,
+            feature=fname,
+            coefficient=round(coef, 4),
+            # Constant z-space offset every domain gets vs. the training mean.
+            zero_fill_z_offset=round(coef * (0.0 - mean) / scale, 4),
+            bias=f"confidence biased {bias_direction} for domains where {fname}=1",
+        )
+
+    # -- Calibration acceptance gate -----------------------------------------
+    metrics = model.get("metrics", {})
+    ece = metrics.get("lr_ece")
+    calibrated_ece = metrics.get("lr_calibrated_ece")
+    calibration_active = bool(model.get("calibration"))
+    if (
+        calibration_active
+        and ece is not None
+        and calibrated_ece is not None
+        and calibrated_ece > ece
+    ):
+        calibration_active = False
+        log.warning(
+            "scorer_calibration_gated_off",
+            artifact=f"{model['version']}@{model['training_date']}",
+            lr_ece=ece,
+            lr_calibrated_ece=calibrated_ece,
+            reason=("artifact metrics say calibration worsens ECE; using raw LR probabilities"),
+        )
+    model["_calibration_active"] = calibration_active
+    return model
+
+
 _MODEL: dict[str, Any] | None = None
 
 
 def _get_model() -> dict[str, Any]:
     global _MODEL  # noqa: PLW0603
     if _MODEL is None:
-        _MODEL = _load_model()
+        _MODEL = _validate_artifact(_load_model())
     return _MODEL
 
 
@@ -139,9 +248,18 @@ def scorer_version() -> str:
 
     The artifact version alone ("v1") is not enough — a retrain keeps the version
     but shifts every probability, so the training date is the discriminator.
+
+    When the artifact carries a calibration layer that the acceptance gate
+    disabled (see ``_validate_artifact``), a ``+uncal`` suffix is appended:
+    the same artifact produces different probabilities calibrated vs. raw, so
+    the two must not share an identity (delta reports diff confidences only
+    within one (scorer_id, scorer_version)).
     """
     model = _get_model()
-    return f"{model['version']}@{model['training_date']}"
+    base = f"{model['version']}@{model['training_date']}"
+    if model.get("calibration") and not model["_calibration_active"]:
+        return f"{base}+uncal"
+    return base
 
 
 def score_confidence(
@@ -158,7 +276,8 @@ def score_confidence(
 ) -> float:
     """Score domain-entity attribution using the learned logistic model.
 
-    Returns a calibrated probability in [0, 1].
+    Returns a probability in [0, 1] — calibrated only if the artifact's own
+    metrics show the calibration layer improves ECE, raw LR otherwise.
     """
     model = _get_model()
     features = model["features"]
@@ -198,9 +317,10 @@ def score_confidence(
 
     prob = 1.0 / (1.0 + math.exp(-z))
 
-    # Apply isotonic calibration if available
+    # Apply isotonic calibration only when the load-time acceptance gate
+    # accepted it (artifact's own metrics say it improves ECE).
     cal = model.get("calibration")
-    if cal:
+    if cal and model["_calibration_active"]:
         prob = _isotonic_interpolate(prob, cal["x"], cal["y"])
 
     return round(prob, 4)

--- a/domain_scout/scorer/logistic_v1.json
+++ b/domain_scout/scorer/logistic_v1.json
@@ -59,6 +59,9 @@
   "threshold": 0.5,
   "regularization_C": 0.1,
   "training_date": "2026-03-01",
+  "inference_unavailable_features": [
+    "org_matches_different_entity"
+  ],
   "gray_zone": [
     0.8,
     0.95

--- a/domain_scout/tests/test_eval.py
+++ b/domain_scout/tests/test_eval.py
@@ -24,6 +24,7 @@ from domain_scout.eval import (
 from domain_scout.models import (
     DiscoveredDomain,
     EntityInput,
+    EvidenceRecord,
     RunMetadata,
     ScoutResult,
 )
@@ -433,3 +434,169 @@ class TestEvalReportJson:
         assert restored.mode == "test"
         assert len(restored.entities) == 1
         assert restored.entities[0].label_id == "rt"
+        # Pre-#183 reports (no learned leg) still validate.
+        assert restored.learned_entities == []
+        assert restored.learned_scorer is None
+
+
+# ---------------------------------------------------------------------------
+# Learned-scorer leg (issue #183: eval must exercise both scorer paths)
+# ---------------------------------------------------------------------------
+
+
+def _make_learned_fixture() -> ScoutResult:
+    """ScoutResult where the learned scorer disagrees with the recorded ranking.
+
+    - filler.com: no cert evidence -> learned leg keeps recorded 0.6
+      (mirrors Scout's fallback when cert_org_names is empty).
+    - acme-cert.com: recorded 0.2, but cert org == company + resolves, so the
+      learned model scores it high (~0.98) and it should re-rank to the top.
+    """
+    return ScoutResult(
+        entity=EntityInput(company_name="Acme Corp", seed_domain=["acme.com"]),
+        domains=[
+            DiscoveredDomain(domain="filler.com", confidence=0.6),
+            DiscoveredDomain(
+                domain="acme-cert.com",
+                confidence=0.2,
+                sources=["ct_org_match"],
+                cert_org_names=["Acme Corp"],
+                resolves=True,
+                evidence=[
+                    EvidenceRecord(
+                        source_type="ct_org_match",
+                        description="cert org match",
+                        cert_id=1,
+                        cert_org="Acme Corp",
+                        similarity_score=0.98,
+                    )
+                ],
+            ),
+        ],
+        run_metadata=RunMetadata(
+            tool_version="0.4.0",
+            timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+            elapsed_seconds=1.0,
+            domains_found=2,
+        ),
+    )
+
+
+class TestLearnedScorerLeg:
+    def test_learned_leg_reranks_by_learned_confidence(self) -> None:
+        from domain_scout.eval import _learned_ranked_domains
+
+        result = _make_learned_fixture()
+        # Recorded ranking: filler.com (0.6) ahead of acme-cert.com (0.2).
+        assert [d.domain for d in result.domains] == ["filler.com", "acme-cert.com"]
+        # Learned leg: acme-cert.com re-scored high, filler.com keeps 0.6.
+        assert _learned_ranked_domains(result) == ["acme-cert.com", "filler.com"]
+
+    def test_baseline_runs_both_scorer_legs(self, tmp_path: Path) -> None:
+        gt = [
+            GroundTruthEntry(
+                label_id="acme",
+                company_name="Acme Corp",
+                seeds=["acme.com"],
+                owned_domains=["acme-cert.com"],
+                not_owned=["filler.com"],
+            )
+        ]
+        baseline_path = tmp_path / "acme.json"
+        baseline_path.write_text(_make_learned_fixture().model_dump_json())
+
+        report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
+
+        assert len(report.entities) == 1
+        assert len(report.learned_entities) == 1
+        # #185 identity of the path that actually ran: raw LR (calibration
+        # gated off by the artifact's own metrics), hence the +uncal suffix.
+        assert report.learned_scorer == "learned_lr/v1@2026-03-01+uncal"
+
+        # Heuristic leg: recorded ranking puts the labeled FP at rank 1.
+        heuristic = report.entities[0].metrics[0]
+        assert heuristic.precision == 0.0
+        assert heuristic.false_positives == 1
+
+        # Learned leg: re-ranked, the owned domain is at rank 1.
+        learned = report.learned_entities[0].metrics[0]
+        assert learned.precision == 1.0
+        assert learned.false_positives == 0
+
+    def test_learned_leg_without_cert_orgs_matches_recorded(self, tmp_path: Path) -> None:
+        """No cert evidence anywhere -> learned leg falls back to recorded ranking."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com", "test.net"],
+                not_owned=["evil.com"],
+            )
+        ]
+        result = _make_scout_result(
+            ["test.com", "evil.com", "test.net"],
+            company_name="TestCo",
+            seeds=["test.com"],
+        )
+        (tmp_path / "test-entity.json").write_text(result.model_dump_json())
+
+        report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(3,))
+        assert report.learned_entities[0].metrics == report.entities[0].metrics
+        assert (
+            report.learned_entities[0].false_positive_domains
+            == report.entities[0].false_positive_domains
+        )
+
+    def test_no_baselines_no_learned_scorer_identity(self, tmp_path: Path) -> None:
+        gt = [
+            GroundTruthEntry(
+                label_id="missing",
+                company_name="Missing Corp",
+                seeds=["missing.com"],
+                owned_domains=["missing.com"],
+            )
+        ]
+        report = evaluate_baseline(gt, baselines_dir=tmp_path)
+        assert report.learned_entities == []
+        assert report.learned_scorer is None
+
+    def test_format_table_includes_learned_section(self, tmp_path: Path) -> None:
+        gt = [
+            GroundTruthEntry(
+                label_id="acme",
+                company_name="Acme Corp",
+                seeds=["acme.com"],
+                owned_domains=["acme-cert.com"],
+                not_owned=["filler.com"],
+            )
+        ]
+        (tmp_path / "acme.json").write_text(_make_learned_fixture().model_dump_json())
+
+        report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
+        table = format_table(report)
+        assert "Learned scorer leg (learned_lr/v1@2026-03-01+uncal)" in table
+        # Both legs render the entity block.
+        assert table.count("acme (Acme Corp, seeds=acme.com)") == 2
+
+    @pytest.mark.asyncio
+    async def test_live_runs_both_scorer_legs(self) -> None:
+        gt = [
+            GroundTruthEntry(
+                label_id="acme",
+                company_name="Acme Corp",
+                seeds=["acme.com"],
+                owned_domains=["acme-cert.com"],
+                not_owned=["filler.com"],
+            )
+        ]
+        with patch("domain_scout.scout.Scout") as mock_scout_cls:
+            mock_scout = mock_scout_cls.return_value
+            mock_scout.discover_async = AsyncMock(return_value=_make_learned_fixture())
+
+            report = await evaluate_live(gt, k_values=(1,))
+
+        assert report.mode == "live"
+        assert report.entities[0].metrics[0].precision == 0.0
+        assert report.learned_entities[0].metrics[0].precision == 1.0
+        assert report.learned_scorer == "learned_lr/v1@2026-03-01+uncal"

--- a/domain_scout/tests/test_scorer.py
+++ b/domain_scout/tests/test_scorer.py
@@ -2,9 +2,38 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import Any
 
+import pytest
+from structlog.testing import capture_logs
+
+from domain_scout import scorer
 from domain_scout.scorer import _clean_name
+
+# A degenerate calibration curve that maps every probability to exactly 0.5:
+# if a score comes back 0.5 the calibration layer ran, otherwise it was skipped.
+_FLAT_CALIBRATION = {"x": [0.0, 1.0], "y": [0.5, 0.5]}
+
+
+def _score_once() -> float:
+    """Score one fixed, evidence-rich domain through the loaded model."""
+    return scorer.score_confidence(
+        domain="acme.com",
+        company_name="Acme Corp",
+        best_similarity=0.9,
+        sources={"ct_org_match"},
+        cert_org_names={"Acme Corp"},
+        resolves=True,
+        evidence_count=3,
+        unique_cert_count=2,
+    )
+
+
+def _artifact(**overrides: Any) -> dict[str, Any]:
+    """Fresh copy of the shipped artifact with optional top-level overrides."""
+    model = scorer._load_model()
+    model.update(overrides)
+    return model
 
 
 @pytest.mark.parametrize(
@@ -29,10 +58,153 @@ def test_clean_name(input_name: str, expected: str) -> None:
 
 def test_scorer_identity_constants() -> None:
     """The learned scorer exposes a stable id and an artifact-derived version."""
-    from domain_scout.scorer import SCORER_ID, _get_model, scorer_version
+    from domain_scout.scorer import SCORER_ID, scorer_version
 
     assert SCORER_ID == "learned_lr"
-    model = _get_model()
-    assert scorer_version() == f"{model['version']}@{model['training_date']}"
     # Pin the shipped artifact so a silent retrain can't reuse an old identity.
-    assert scorer_version() == "v1@2026-03-01"
+    # The +uncal suffix records that the acceptance gate disabled this
+    # artifact's calibration layer (lr_calibrated_ece 0.2182 > lr_ece 0.0072),
+    # so raw-LR probabilities never share an identity with calibrated ones.
+    assert scorer_version() == "v1@2026-03-01+uncal"
+
+
+# ---------------------------------------------------------------------------
+# Calibration acceptance gate (issue #183)
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationGate:
+    def test_shipped_artifact_gates_calibration_off(self) -> None:
+        """The shipped artifact's own metrics reject its calibration layer."""
+        model = scorer._validate_artifact(scorer._load_model())
+        assert model["metrics"]["lr_calibrated_ece"] > model["metrics"]["lr_ece"]
+        assert model["_calibration_active"] is False
+
+    def test_bad_calibration_skipped_at_scoring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With calibrated ECE worse than raw, the flat curve must NOT run."""
+        model = _artifact(calibration=_FLAT_CALIBRATION)
+        # Shipped metrics already say calibration is worse (0.2182 > 0.0072).
+        monkeypatch.setattr(scorer, "_MODEL", scorer._validate_artifact(model))
+
+        prob = _score_once()
+        assert prob != 0.5  # flat curve would have mapped everything to 0.5
+        assert 0.0 < prob < 1.0
+
+    def test_good_calibration_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A future artifact whose metrics show good calibration gets it back."""
+        model = _artifact(calibration=_FLAT_CALIBRATION)
+        model["metrics"]["lr_calibrated_ece"] = 0.001  # better than lr_ece 0.0072
+        monkeypatch.setattr(scorer, "_MODEL", scorer._validate_artifact(model))
+
+        assert _score_once() == 0.5
+
+    def test_missing_ece_metrics_keep_calibration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No ECE evidence -> no gate: pre-#183 behavior (calibration applied)."""
+        model = _artifact(calibration=_FLAT_CALIBRATION, metrics={})
+        monkeypatch.setattr(scorer, "_MODEL", scorer._validate_artifact(model))
+
+        assert scorer._MODEL is not None
+        assert scorer._MODEL["_calibration_active"] is True
+        assert _score_once() == 0.5
+
+    def test_partial_ece_metrics_keep_calibration(self) -> None:
+        """Only one of the two ECE metrics present -> no gate (no comparison)."""
+        model = _artifact(calibration=_FLAT_CALIBRATION)
+        del model["metrics"]["lr_calibrated_ece"]
+        assert scorer._validate_artifact(model)["_calibration_active"] is True
+
+        model = _artifact(calibration=_FLAT_CALIBRATION)
+        del model["metrics"]["lr_ece"]
+        assert scorer._validate_artifact(model)["_calibration_active"] is True
+
+    def test_gate_logs_once_at_load_not_per_domain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(scorer, "_MODEL", None)
+        with capture_logs() as logs:
+            scorer._get_model()
+            events = [entry["event"] for entry in logs]
+            assert events.count("scorer_calibration_gated_off") == 1
+
+            load_time_count = len(logs)
+            _score_once()
+            _score_once()
+            assert len(logs) == load_time_count  # scoring adds no log entries
+
+    def test_gate_warning_carries_artifact_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(scorer, "_MODEL", None)
+        with capture_logs() as logs:
+            scorer._get_model()
+        (entry,) = [e for e in logs if e["event"] == "scorer_calibration_gated_off"]
+        assert entry["artifact"] == "v1@2026-03-01"
+        assert entry["lr_ece"] == 0.0072
+        assert entry["lr_calibrated_ece"] == 0.2182
+
+
+# ---------------------------------------------------------------------------
+# Feature-availability contract (issue #183)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureAvailabilityContract:
+    def test_declared_zero_filled_feature_warned_with_bias(self) -> None:
+        """org_matches_different_entity is declared inference-unavailable."""
+        with capture_logs() as logs:
+            scorer._validate_artifact(scorer._load_model())
+
+        (entry,) = [e for e in logs if e["event"] == "scorer_feature_zero_filled"]
+        assert entry["feature"] == "org_matches_different_entity"
+        assert entry["coefficient"] == pytest.approx(0.2044, abs=1e-4)
+        # Positive coefficient + zero-fill -> scores biased low where the
+        # signal would have been 1.
+        assert "biased low" in entry["bias"]
+        assert entry["zero_fill_z_offset"] == pytest.approx(-0.0201, abs=1e-4)
+
+    def test_undeclared_zero_filled_feature_warns_as_undeclared(self) -> None:
+        model = scorer._load_model()
+        del model["inference_unavailable_features"]
+        with capture_logs() as logs:
+            scorer._validate_artifact(model)
+
+        events = [e["event"] for e in logs]
+        assert "scorer_feature_availability_undeclared" in events
+        assert "scorer_feature_zero_filled" not in events
+
+    def test_unknown_feature_rejected_at_load(self) -> None:
+        """A feature the scorer can't even zero-fill fails loud at load."""
+        model = scorer._load_model()
+        model["features"] = [*model["features"], "bogus_feature"]
+        with pytest.raises(ValueError, match="bogus_feature"):
+            scorer._validate_artifact(model)
+
+
+# ---------------------------------------------------------------------------
+# Version stamp composition (issue #183 x #185)
+# ---------------------------------------------------------------------------
+
+
+class TestScorerVersionStamp:
+    def test_gated_off_calibration_suffixes_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(scorer, "_MODEL", None)  # force reload of shipped artifact
+        assert scorer.scorer_version() == "v1@2026-03-01+uncal"
+
+    def test_accepted_calibration_keeps_plain_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        model = _artifact(calibration=_FLAT_CALIBRATION)
+        model["metrics"]["lr_calibrated_ece"] = 0.001
+        monkeypatch.setattr(scorer, "_MODEL", scorer._validate_artifact(model))
+        assert scorer.scorer_version() == "v1@2026-03-01"
+
+    def test_scout_stamps_gated_identity(self) -> None:
+        """The #185 stamp on scored domains reflects the path that actually ran:
+        raw-LR (gated) probabilities are stamped +uncal, composing with #183."""
+        from domain_scout.config import ScoutConfig
+        from domain_scout.scout import Scout, _DomainAccum
+
+        accum = _DomainAccum()
+        accum.sources = {"ct_org_match"}
+        accum.cert_org_names = {"TestCo"}
+        accum.resolves = True
+        scout = Scout(config=ScoutConfig(use_learned_scorer=True))
+        scout._score_confidence(accum, "TestCo", ["test.com"], domain="example.com")
+        assert accum.scorer_id == "learned_lr"
+        assert accum.scorer_version == "v1@2026-03-01+uncal"


### PR DESCRIPTION
Closes #183

## What

The learned-scorer artifact ships self-contradicting metrics that nothing consumed. This PR makes inference read the artifact's own persisted self-assessment (design gate #4: the unreviewed persisted model artifact finally gets a reviewer — itself):

1. **Calibration acceptance gate** (`scorer/__init__.py`): at load, skip the isotonic calibration layer when the artifact reports `lr_calibrated_ece > lr_ece`. The shipped v1 artifact says 0.2182 vs 0.0072 (30× worse), so raw LR probabilities are now used. The gate reads only artifact metadata — a future artifact with good calibration automatically gets the layer back. Logged once at load, not per domain. Missing/partial ECE metrics → no gate (pre-#183 behavior, calibration kept).
2. **Feature-availability contract**: the artifact schema gains `inference_unavailable_features`; `org_matches_different_entity` (zero-filled at inference, coefficient +0.204) is declared there. The loader warns once at load with the documented bias direction (confidence biased **low** for domains where the signal would fire; constant z-offset −0.0201 vs training mean) and raises for features it can't compute at all. Coefficients untouched — no retraining.
3. **Eval runs both scorer paths** (`eval.py`): `make eval` now reports a heuristic leg (recorded ranking) and a learned leg (persisted evidence re-scored through the model, mirroring `Scout._score_confidence`'s gating), so the learned scorer is exercised pre-ship.
4. **Identity stamps compose with #185**: `scorer_version()` stamps `+uncal` when the gate disables calibration (`v1@2026-03-01+uncal`), so raw-LR probabilities never share an identity with calibrated ones; `delta.py` treats the version as opaque, so a code-version fleet mix surfaces as a `scorer_changed` transition instead of bogus confidence deltas.

## Zero-filled feature: why declare-and-warn, not adjust

Adjusting the coefficient (or folding the zero-fill into the intercept) changes every probability the model emits — that's a retrain-shaped change requiring eval ground truth, out of scope per the issue. Zero-filling already yields a *constant* offset (−0.0201 in z-space vs the training mean), so the honest minimal fix is to make the train/serve mismatch a declared, logged property of the artifact rather than a silent one.

## Verification

- `uv run pytest domain_scout/tests -m "not integration" -v --cov-report=term --cov-report=xml` (exact CI invocation): **758 passed** (739 baseline + 19 new), 4 deselected; coverage **93.94%** (gate ≥92).
- `uv run ruff check domain_scout` → All checks passed; `uv run ruff format --check domain_scout` → 50 files already formatted; `uv run mypy domain_scout/ --ignore-missing-imports` → no issues in 50 files.
- End-to-end: ran `python -m domain_scout.eval --mode baseline` against a synthetic baseline — both legs render, gate warnings fire once at startup, learned leg re-ranks (NDCG 0.631 → 1.000 on the fixture).
- `scout.py` diff is empty; `use_learned_scorer` defaults `False` — the default heuristic scoring path is byte-identical, so the existing eval numbers (Behavioral Preservation rule) are unchanged.

## Adversarial self-review (findings + disposition)

Dispatched an adversarial data reviewer on the final diff. Answers to the three standing questions:

**(a) Anything unnecessarily clever or leftover from drafting?** None found (reviewer confirmed: no unused imports, dead branches, or debug leftovers). The flat-calibration-curve test trick (curve maps everything to 0.5, so 0.5 ⇔ calibration ran) was checked for vacuity: the fixture's raw probability is 0.9379, nowhere near the sentinel.

**(b) Are the PR-body claims verifiable as stated?** Test/coverage/lint numbers above are from the exact commands shown, run on the final tree (exit 0). One claim was *corrected* after review: the eval learned leg is an **approximation** of a live learned run, not a faithful replay — it re-scores from persisted post-pipeline state, which differs in three ways (no `_infra_boost` +0.05 addend; post-boost `shared_infra` source tags flip `has_shared_infra`; `_dedup_evidence` can shrink `evidence_density`). Reviewer measured up to ~0.04 probability gap on boosted domains. Now documented in `_learned_ranked_domains` and the CHANGELOG instead of overclaimed. A faithful replay would need pre-output accum state persisted — separate issue if wanted.

**(c) Does this match the file's existing patterns?** `log = structlog.get_logger()` matches the 11 other modules; artifact identity pinning follows the existing `test_scorer_identity_constants` pattern; `EvalReport` additions are additive with defaults, same as the #184 schema-1.1 approach (old report JSON without the new keys validates — reviewer verified).

**(d) Gate #4:** the artifact's persisted self-assessment is finally consumed — its own `lr_ece`/`lr_calibrated_ece` decide the calibration layer, its own schema declares feature availability, and `_validate_artifact` rejects artifacts whose features inference can't supply.

Intentionally skipped: `scale == 0` guard in the load-time warning math (reviewer nit) — a zero-scale feature makes the artifact unscoreable at all (`score_confidence` divides by it per domain), so crashing at load is strictly earlier than the per-domain crash it would otherwise hit; no shipped value is zero.

Known limitation (pre-existing, unchanged): whether `lr_ece`/`lr_calibrated_ece` were computed on held-out data is a property of the training pipeline, not this repo; the gate consumes them as recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4