### PR TITLE
Pool one httpx client per scan; surface corroboration errors (#166, #167)

### DIFF
--- a/domain_scout/cache.py
+++ b/domain_scout/cache.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 import structlog
 
 if TYPE_CHECKING:
+    import httpx
+
     from domain_scout.sources.ct_logs import CTLogSource
     from domain_scout.sources.rdap import RDAPLookup
 
@@ -202,9 +204,11 @@ class DuckDBCache:
 class CTSource(Protocol):
     """Protocol for CT log source (real or cached)."""
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]: ...
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]: ...
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]: ...
     async def get_cert_org(self, cert_id: int) -> str | None: ...
 
@@ -213,8 +217,12 @@ class CTSource(Protocol):
 class RDAPSource(Protocol):
     """Protocol for RDAP lookup (real or cached)."""
 
-    async def get_registrant_org(self, domain: str) -> str | None: ...
-    async def get_registrant_info(self, domain: str) -> dict[str, str | None]: ...
+    async def get_registrant_org(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> str | None: ...
+    async def get_registrant_info(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> dict[str, str | None]: ...
 
 
 class CachedCTLogSource:
@@ -224,13 +232,15 @@ class CachedCTLogSource:
         self._inner = inner
         self._cache = cache
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]:
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
         loop = asyncio.get_running_loop()
         cached = await loop.run_in_executor(None, self._cache.get_ct, f"domain:{domain}")
         if cached is not None:
             log.debug("cache.ct_hit", query=f"domain:{domain}")
             return cached
-        result = await self._inner.search_by_domain(domain)
+        result = await self._inner.search_by_domain(domain, client=client)
         try:
             await loop.run_in_executor(None, self._cache.put_ct, f"domain:{domain}", result)
         except Exception as exc:
@@ -238,7 +248,7 @@ class CachedCTLogSource:
         return result
 
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
         key = f"org:{org_name}:verify={verify_org}"
         loop = asyncio.get_running_loop()
@@ -246,7 +256,7 @@ class CachedCTLogSource:
         if cached is not None:
             log.debug("cache.ct_hit", query=key)
             return cached
-        result = await self._inner.search_by_org(org_name, verify_org=verify_org)
+        result = await self._inner.search_by_org(org_name, verify_org=verify_org, client=client)
         try:
             await loop.run_in_executor(None, self._cache.put_ct, key, result)
         except Exception as exc:
@@ -264,26 +274,30 @@ class CachedRDAPLookup:
         self._inner = inner
         self._cache = cache
 
-    async def get_registrant_org(self, domain: str) -> str | None:
+    async def get_registrant_org(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> str | None:
         loop = asyncio.get_running_loop()
         cached = await loop.run_in_executor(None, self._cache.get_rdap, f"org:{domain}")
         if cached is not None:
             log.debug("cache.rdap_hit", query=f"org:{domain}")
             return cached.get("org")
-        result = await self._inner.get_registrant_org(domain)
+        result = await self._inner.get_registrant_org(domain, client=client)
         try:
             await loop.run_in_executor(None, self._cache.put_rdap, f"org:{domain}", {"org": result})
         except Exception as exc:
             log.warning("cache.write_failed", query=f"org:{domain}", error=str(exc))
         return result
 
-    async def get_registrant_info(self, domain: str) -> dict[str, str | None]:
+    async def get_registrant_info(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> dict[str, str | None]:
         loop = asyncio.get_running_loop()
         cached = await loop.run_in_executor(None, self._cache.get_rdap, f"info:{domain}")
         if cached is not None:
             log.debug("cache.rdap_hit", query=f"info:{domain}")
             return cached
-        result = await self._inner.get_registrant_info(domain)
+        result = await self._inner.get_registrant_info(domain, client=client)
         try:
             await loop.run_in_executor(None, self._cache.put_rdap, f"info:{domain}", result)
         except Exception as exc:

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import csv
 import re
+import ssl
 import time
 from datetime import UTC, datetime
 from importlib.metadata import version as _pkg_version
 from typing import TYPE_CHECKING, Any
 
+import certifi
 import httpx
 import structlog
 
@@ -57,6 +59,31 @@ from domain_scout.sources.rdap import RDAPLookup
 
 log = structlog.get_logger()
 _TOOL_VERSION = _pkg_version("domain-scout-ct")
+
+# Module-level SSL context for the per-scan shared HTTP client (#166).
+# A bare httpx.AsyncClient() builds a fresh SSL context per instance
+# (measurable synchronous CPU); building it once and passing it as verify=
+# keeps per-scan client construction cheap. Mirrors ds-api PR #72.
+# Built from certifi's CA bundle to match httpx's own default trust anchors
+# (httpx uses certifi.where()); a bare ssl.create_default_context() would
+# silently switch to the system OpenSSL store.
+_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+
+
+def _record_check_error(phase: str, domain: str, exc: Exception, errors: list[str]) -> None:
+    """Record a swallowed corroboration/boost check exception consistently (#167).
+
+    The corroboration phases (infra, rdap, fingerprint) run per-domain checks
+    whose failures were previously dropped silently. Surface each one to the
+    debug log, the SOURCE_ERRORS_TOTAL metric, and the scan's error channel
+    (``RunMetadata.errors``) so a systematic fault is visible rather than
+    masked as "no signal found". The scan still continues; the check is a
+    best-effort boost, not a hard dependency.
+    """
+    log.debug("scout.corroborate_check_error", phase=phase, domain=domain, error=str(exc))
+    inc(SOURCE_ERRORS_TOTAL, source=phase)
+    errors.append(f"{phase} check failed for {domain}: {exc}")
+
 
 # Signal classification for evidence transparency.
 # Maps source_type prefixes to (signal_type, weight).
@@ -422,6 +449,22 @@ class Scout:
         return await self._discover(entity)
 
     async def _discover(self, entity: EntityInput) -> ScoutResult:
+        # One pooled HTTP client per scan (#166), scoped to this call via
+        # async with so it never outlives the event loop that created it
+        # (the CLI runs asyncio.run per invocation). The default timeout
+        # matches http_timeout; RDAP overrides follow_redirects per-request,
+        # RDAP/CT-JSON pin their timeout per-request, and GeoDNS uses the
+        # client default. Deliberately scan-scoped rather than stored on the
+        # instance + closed in Scout.close(): a persistent client would risk
+        # cross-event-loop reuse (the hazard called out in #166).
+        async with httpx.AsyncClient(
+            verify=_SSL_CONTEXT, timeout=self.config.http_timeout
+        ) as scan_client:
+            return await self._run_pipeline(entity, scan_client)
+
+    async def _run_pipeline(
+        self, entity: EntityInput, scan_client: httpx.AsyncClient
+    ) -> ScoutResult:
         self._dns.reset()
         t0 = time.monotonic()
         total_budget = self.config.total_timeout
@@ -462,7 +505,7 @@ class Scout:
         if self.config.discovery_mode != "fingerprint" and entity.company_name:
             independent_tasks.append(
                 asyncio.create_task(
-                    self._strategy_org_search(entity.company_name, errors),
+                    self._strategy_org_search(entity.company_name, errors, client=scan_client),
                     name="org_search",
                 )
             )
@@ -488,6 +531,7 @@ class Scout:
                             sub_name,
                             errors,
                             source_tag="ct_gleif_subsidiary",
+                            client=scan_client,
                         ),
                         name=f"gleif_sub:{sub_name[:30]}",
                     )
@@ -505,6 +549,7 @@ class Scout:
                             sub_name,
                             errors,
                             source_tag="ct_subsidiary_match",
+                            client=scan_client,
                         ),
                         name=f"subsidiary:{sub_name[:30]}",
                     )
@@ -519,7 +564,9 @@ class Scout:
         seed_tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
         for sd in seeds:
             seed_tasks[sd] = asyncio.create_task(
-                self._validate_seed(sd, entity.company_name, seeds, errors, seed_to_base),
+                self._validate_seed(
+                    sd, entity.company_name, seeds, errors, seed_to_base, client=scan_client
+                ),
                 name=f"seed_validation:{sd}",
             )
 
@@ -583,7 +630,7 @@ class Scout:
                 seen_org_searches.add(org_name)
                 dependent_tasks.append(
                     asyncio.create_task(
-                        self._strategy_org_search(org_name, errors),
+                        self._strategy_org_search(org_name, errors, client=scan_client),
                         name=f"org_search_seed:{sd}",
                     )
                 )
@@ -597,6 +644,7 @@ class Scout:
                         entity.company_name,
                         errors,
                         ct_records=seed_ct_records.get(sd),
+                        client=scan_client,
                     ),
                     name=f"seed_expansion:{sd}",
                 )
@@ -651,11 +699,13 @@ class Scout:
             if failed_domains:
                 log.info("scout.geodns_rescue", count=len(failed_domains))
                 try:
-                    async with httpx.AsyncClient(timeout=15.0) as client:
-                        geodns_map = await asyncio.wait_for(
-                            self._dns.bulk_geodns_resolve(failed_domains, client),
-                            timeout=max(1.0, _remaining() - 3.0),
-                        )
+                    # Reuse the per-scan pooled client (#166). GeoDNS keeps the
+                    # scan client's default timeout (http_timeout, 15s by default —
+                    # identical to the former dedicated 15s client).
+                    geodns_map = await asyncio.wait_for(
+                        self._dns.bulk_geodns_resolve(failed_domains, scan_client),
+                        timeout=max(1.0, _remaining() - 3.0),
+                    )
                     for domain, did_resolve in geodns_map.items():
                         if not did_resolve:
                             continue
@@ -674,11 +724,15 @@ class Scout:
                     timed_out = True
                     errors.append("GeoDNS resolution timed out")
 
-        # Step 3c: RDAP corroboration on top resolving candidates
+        # Step 3c: RDAP corroboration on top resolving candidates.
+        # Caller owns the budget-derived timeout (one idiom across all three
+        # corroboration phases, #167); the phase itself has no inner timeout.
         if _remaining() > 5.0:
             try:
                 await asyncio.wait_for(
-                    self._rdap_corroborate(domain_evidence, entity.company_name),
+                    self._rdap_corroborate(
+                        domain_evidence, entity.company_name, errors, client=scan_client
+                    ),
                     timeout=min(15.0, _remaining() - 3.0),
                 )
             except TimeoutError:
@@ -688,7 +742,7 @@ class Scout:
         if self.config.discovery_mode == "fingerprint" and seeds and _remaining() > 3.0:
             try:
                 await asyncio.wait_for(
-                    self._fingerprint_corroborate(domain_evidence, seeds),
+                    self._fingerprint_corroborate(domain_evidence, seeds, errors),
                     timeout=min(30.0, _remaining() - 2.0),
                 )
             except TimeoutError:
@@ -724,7 +778,16 @@ class Scout:
         if not reference and confirmed_domains:
             reference = confirmed_domains[0]
         if reference and len(domain_evidence) <= 50 and _remaining() > 1.0:
-            await self._infra_boost(reference, domain_evidence)
+            # Budget-derived timeout, caller-owned (#167): same idiom as the
+            # RDAP/fingerprint phases. Previously infra_boost hardcoded 10s
+            # internally and swallowed its timeout without recording it.
+            try:
+                await asyncio.wait_for(
+                    self._infra_boost(reference, domain_evidence, errors),
+                    timeout=min(10.0, max(1.0, _remaining() - 1.0)),
+                )
+            except TimeoutError:
+                errors.append("Infrastructure boost timed out")
 
         # Build output
         domains = self._build_output(domain_evidence, seeds)
@@ -764,18 +827,19 @@ class Scout:
         all_seeds: list[str],
         errors: list[str],
         seed_to_base: dict[str, str | None] | None = None,
+        client: httpx.AsyncClient | None = None,
     ) -> dict[str, Any]:
         """Returns dict with assessment, org_name, co_hosted_seeds, and ct_records."""
         resolves = await self._dns.resolves(seed)
 
         rdap_org: str | None = None
         try:
-            rdap_org = await self._rdap.get_registrant_org(seed)
+            rdap_org = await self._rdap.get_registrant_org(seed, client=client)
         except Exception as exc:
             errors.append(f"RDAP lookup failed for {seed}: {exc}")
 
         # Also check CT for the org name on certs (shared with seed expansion)
-        ct_records = await self._ct.search_by_domain(seed)
+        ct_records = await self._ct.search_by_domain(seed, client=client)
         cert_orgs: set[str] = set()
 
         # Build reverse lookup: base domain -> original seed domain (excluding current seed)
@@ -906,10 +970,11 @@ class Scout:
         org_name: str,
         errors: list[str],
         source_tag: str = "ct_org_match",
+        client: httpx.AsyncClient | None = None,
     ) -> list[tuple[str, _DomainAccum]]:
         results: list[tuple[str, _DomainAccum]] = []
         try:
-            records = await self._ct.search_by_org(org_name)
+            records = await self._ct.search_by_org(org_name, client=client)
         except CTOrgSearchUnavailableError as exc:
             # Degraded, not just failed: org search was skipped entirely (#163).
             inc(SOURCE_ERRORS_TOTAL, source="ct")
@@ -933,13 +998,14 @@ class Scout:
         company_name: str,
         errors: list[str],
         ct_records: list[dict[str, Any]] | None = None,
+        client: httpx.AsyncClient | None = None,
     ) -> list[tuple[str, _DomainAccum]]:
         results: list[tuple[str, _DomainAccum]] = []
         if ct_records is not None:
             records = ct_records
         else:
             try:
-                records = await self._ct.search_by_domain(seed_domain)
+                records = await self._ct.search_by_domain(seed_domain, client=client)
             except Exception as exc:
                 inc(SOURCE_ERRORS_TOTAL, source="ct")
                 errors.append(f"CT seed expansion failed: {exc}")
@@ -1214,8 +1280,15 @@ class Scout:
 
         return round(score, 2)
 
-    async def _infra_boost(self, reference: str, evidence: dict[str, _DomainAccum]) -> None:
-        """Small confidence boost for domains sharing infra with a reference domain."""
+    async def _infra_boost(
+        self, reference: str, evidence: dict[str, _DomainAccum], errors: list[str]
+    ) -> None:
+        """Small confidence boost for domains sharing infra with a reference domain.
+
+        Per-domain check failures are recorded (#167) rather than swallowed. The
+        caller wraps this call with a budget-derived timeout (the same idiom as
+        the RDAP/fingerprint phases), so there is no inner timeout here.
+        """
         # Select top candidates by confidence, capped
         candidates = [
             (domain, accum)
@@ -1243,23 +1316,27 @@ class Scout:
                 # Only cross_seed_verified (0.90 base) should reach 1.00.
                 max_conf = 1.0 if "cross_seed_verified" in accum.sources else 0.95
                 accum.confidence = round(min(max_conf, accum.confidence + 0.05), 2)
-            except Exception:
-                pass
+            except Exception as exc:
+                _record_check_error("infra", domain, exc, errors)
 
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*[_check(d, a) for d, a in candidates]),
-                timeout=10.0,
-            )
-        except TimeoutError:
-            log.warning("scout.infra_boost_timeout", checked=len(candidates))
+        await asyncio.gather(*[_check(d, a) for d, a in candidates])
 
     # --- RDAP corroboration ---
 
     async def _rdap_corroborate(
-        self, domain_evidence: dict[str, _DomainAccum], company_name: str
+        self,
+        domain_evidence: dict[str, _DomainAccum],
+        company_name: str,
+        errors: list[str],
+        client: httpx.AsyncClient | None = None,
     ) -> None:
-        """Query RDAP on top resolving candidates and add corroborating evidence."""
+        """Query RDAP on top resolving candidates and add corroborating evidence.
+
+        ``client`` is the per-scan pooled HTTP client (#166); ``errors`` is the
+        scan error channel — per-domain check failures are recorded there (#167)
+        rather than logged-and-dropped. The caller wraps this with a
+        budget-derived timeout, so there is no inner timeout here.
+        """
         # Select resolving candidates without existing rdap_registrant_match
         candidates = [
             (domain, accum)
@@ -1275,7 +1352,7 @@ class Scout:
 
         async def _check(domain: str, accum: _DomainAccum) -> None:
             try:
-                rdap_org = await self._rdap.get_registrant_org(domain)
+                rdap_org = await self._rdap.get_registrant_org(domain, client=client)
                 if not rdap_org:
                     return
 
@@ -1313,15 +1390,9 @@ class Scout:
                     )
                 )
             except Exception as exc:
-                log.debug("scout.rdap_corroborate_error", domain=domain, error=str(exc))
+                _record_check_error("rdap", domain, exc, errors)
 
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*[_check(d, a) for d, a in candidates]),
-                timeout=15.0,
-            )
-        except TimeoutError:
-            log.warning("scout.rdap_corroborate_timeout", checked=len(candidates))
+        await asyncio.gather(*[_check(d, a) for d, a in candidates])
 
     # --- Fingerprint corroboration ---
 
@@ -1329,6 +1400,7 @@ class Scout:
         self,
         domain_evidence: dict[str, _DomainAccum],
         seed_domains: list[str],
+        errors: list[str],
     ) -> None:
         """Extract DNS fingerprints from seeds and compare against candidates.
 
@@ -1352,7 +1424,13 @@ class Scout:
         seed_fps: dict[str, DNSFingerprint] = {}
         for sd_base, result in zip(bases, fp_results, strict=True):
             if isinstance(result, BaseException):
-                log.debug("scout.fingerprint_extract_error", seed=sd_base, error=str(result))
+                # Record genuine seed-extraction faults on the error channel
+                # (#167) — the same treatment as the candidate side, so a
+                # systematic failure isn't masked as "no seed signals". Leave
+                # non-Exception BaseExceptions (cancellation) to the caller's
+                # timeout handling.
+                if isinstance(result, Exception):
+                    _record_check_error("fingerprint", sd_base, result, errors)
                 continue
             if not result.has_signals:
                 continue
@@ -1394,7 +1472,8 @@ class Scout:
             async with sem:
                 try:
                     candidate_fp = await extract_fingerprint(domain, self._dns)
-                except Exception:
+                except Exception as exc:
+                    _record_check_error("fingerprint", domain, exc, errors)
                     return
 
                 # Compare against all seed fingerprints, take best match

--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -246,12 +246,18 @@ class CTLogSource:
 
     # --- Public API ---
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]:
-        """Search CT logs for certs matching a domain (FTS). Returns raw cert records."""
-        return await self._pg_query_with_fallback(domain)
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
+        """Search CT logs for certs matching a domain (FTS). Returns raw cert records.
+
+        ``client``: optional caller-owned pool (#166) reused for the JSON API
+        fallback; the Postgres path uses psycopg2 and ignores it.
+        """
+        return await self._pg_query_with_fallback(domain, client=client)
 
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
         """Search CT logs for certs where the subject Organization matches org_name.
 
@@ -260,8 +266,12 @@ class CTLogSource:
         Raises CTOrgSearchUnavailableError when ``verify_org=True`` and Postgres
         is unavailable: the JSON API fallback lacks the subject organization, so
         every record would be filtered out — a silent zero (#163).
+
+        ``client``: optional caller-owned pool (#166) reused for the JSON fallback.
         """
-        records = await self._pg_query_with_fallback(org_name, can_use_json=not verify_org)
+        records = await self._pg_query_with_fallback(
+            org_name, can_use_json=not verify_org, client=client
+        )
         if not verify_org:
             return records
         # Filter to only certs whose subject O= field roughly matches
@@ -353,17 +363,29 @@ class CTLogSource:
 
     # --- JSON API fallback ---
 
-    async def _json_query(self, search_term: str) -> list[dict[str, object]]:
-        """Fall back to the crt.sh JSON API."""
+    async def _json_query(
+        self, search_term: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
+        """Fall back to the crt.sh JSON API.
+
+        ``client``: when provided, reuse this caller-owned pooled client (#166)
+        with the timeout applied per-request; otherwise construct and close a
+        per-call client (standalone/test path, unchanged).
+        """
         async with self._semaphore:
             # Try domain search
             url = f"{self._cfg.crtsh_json_base_url}/"
             params: dict[str, str] = {"q": search_term, "output": "json"}
             log.info("ct.json_query", url=url, params=params)
-            async with httpx.AsyncClient(timeout=self._cfg.http_timeout) as client:
-                resp = await client.get(url, params=params)
+            if client is not None:
+                resp = await client.get(url, params=params, timeout=self._cfg.http_timeout)
                 resp.raise_for_status()
                 data = resp.json()
+            else:
+                async with httpx.AsyncClient(timeout=self._cfg.http_timeout) as own_client:
+                    resp = await own_client.get(url, params=params)
+                    resp.raise_for_status()
+                    data = resp.json()
 
         certs: dict[int, dict[str, object]] = {}
         san_sets: dict[int, set[str]] = {}
@@ -396,19 +418,25 @@ class CTLogSource:
     # --- Combined with retry/fallback ---
 
     async def _pg_query_with_fallback(
-        self, search_term: str, *, can_use_json: bool = True
+        self,
+        search_term: str,
+        *,
+        can_use_json: bool = True,
+        client: httpx.AsyncClient | None = None,
     ) -> list[dict[str, object]]:
         """Try Postgres with retries, fall back to JSON API.
 
         With ``can_use_json=False`` (org searches that must verify O=), a Postgres
         failure raises CTOrgSearchUnavailableError instead of falling back.
+
+        ``client``: optional caller-owned pool (#166) threaded to the JSON fallback.
         """
         breaker = self._active_breaker
 
         if not breaker.should_allow():
             log.warning("ct.circuit_breaker_skip_pg", state=breaker.state)
             return await self._json_fallback(
-                search_term, last_pg_error=None, can_use_json=can_use_json
+                search_term, last_pg_error=None, can_use_json=can_use_json, client=client
             )
 
         last_err: Exception | None = None
@@ -431,7 +459,7 @@ class CTLogSource:
 
         breaker.record_failure()
         return await self._json_fallback(
-            search_term, last_pg_error=last_err, can_use_json=can_use_json
+            search_term, last_pg_error=last_err, can_use_json=can_use_json, client=client
         )
 
     async def _json_fallback(
@@ -440,6 +468,7 @@ class CTLogSource:
         *,
         last_pg_error: Exception | None,
         can_use_json: bool = True,
+        client: httpx.AsyncClient | None = None,
     ) -> list[dict[str, object]]:
         """Fall back to JSON API after Postgres failure or circuit breaker skip.
 
@@ -462,7 +491,7 @@ class CTLogSource:
         if last_pg_error is not None:
             log.warning("ct.pg_failed_falling_back_to_json", error=str(last_pg_error))
         try:
-            return await self._json_query(search_term)
+            return await self._json_query(search_term, client=client)
         except Exception as exc:
             inc(CT_QUERIES_TOTAL, backend="json", status="error")
             log.error(

--- a/domain_scout/sources/ctscout_remote.py
+++ b/domain_scout/sources/ctscout_remote.py
@@ -30,13 +30,24 @@ class CTScoutRemoteSource:
         self._timeout = config.http_timeout
 
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
-        """Search CTScout warehouse by organization name."""
+        """Search CTScout warehouse by organization name.
+
+        ``client`` is accepted for CTSource protocol compatibility (#166) but
+        unused — this source POSTs to a different host (ctscout.dev) with its
+        own per-call client and API-key header.
+        """
         return await self._query(company_name=org_name)
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]:
-        """Search CTScout warehouse by apex domain."""
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
+        """Search CTScout warehouse by apex domain.
+
+        ``client`` is accepted for CTSource protocol compatibility (#166) but
+        unused — see ``search_by_org``.
+        """
         return await self._query(seed_domain=[domain])
 
     async def get_cert_org(self, cert_id: int) -> str | None:

--- a/domain_scout/sources/local_parquet.py
+++ b/domain_scout/sources/local_parquet.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 import structlog
 
 if TYPE_CHECKING:
+    import httpx
+
     from domain_scout.config import ScoutConfig
     from domain_scout.sources.ct_logs import CTLogSource
 
@@ -97,9 +99,13 @@ class LocalParquetSource:
         return [r[0] for r in result if r[0]]
 
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
-        """Search warehouse by org name using fuzzy matching."""
+        """Search warehouse by org name using fuzzy matching.
+
+        ``client`` is accepted for CTSource protocol compatibility (#166) but
+        unused — the local warehouse reads DuckDB, not HTTP.
+        """
         from rapidfuzz import process as rfprocess
         from rapidfuzz.utils import default_process
 
@@ -135,8 +141,14 @@ class LocalParquetSource:
         rows = result.fetchall()
         return [_row_to_record(r, columns) for r in rows]
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]:
-        """Search warehouse by exact domain or suffix match."""
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
+        """Search warehouse by exact domain or suffix match.
+
+        ``client`` is accepted for CTSource protocol compatibility (#166) but
+        unused — the local warehouse reads DuckDB, not HTTP.
+        """
         sql = (
             "SELECT fingerprint, org_raw, "
             "MIN(not_before) AS not_before, MAX(not_after) AS not_after, "
@@ -170,20 +182,22 @@ class HybridCTSource:
         self._remote = remote
 
     async def search_by_org(
-        self, org_name: str, *, verify_org: bool = True
+        self, org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
         results = await self._local.search_by_org(org_name, verify_org=verify_org)
         if results:
             return results
         log.debug("hybrid.fallback_to_remote", method="search_by_org", query=org_name)
-        return await self._remote.search_by_org(org_name, verify_org=verify_org)
+        return await self._remote.search_by_org(org_name, verify_org=verify_org, client=client)
 
-    async def search_by_domain(self, domain: str) -> list[dict[str, object]]:
+    async def search_by_domain(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
         results = await self._local.search_by_domain(domain)
         if results:
             return results
         log.debug("hybrid.fallback_to_remote", method="search_by_domain", query=domain)
-        return await self._remote.search_by_domain(domain)
+        return await self._remote.search_by_domain(domain, client=client)
 
     async def get_cert_org(self, cert_id: int) -> str | None:
         return await self._remote.get_cert_org(cert_id)

--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -160,20 +160,27 @@ class RDAPLookup:
                 recovery_timeout=config.rdap_cb_recovery_timeout,
             )
 
-    async def get_registrant_org(self, domain: str) -> str | None:
-        """Return the registrant organization name for a domain, or None."""
+    async def get_registrant_org(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> str | None:
+        """Return the registrant organization name for a domain, or None.
+
+        ``client``: optional caller-owned shared pool (#166); see ``_query``.
+        """
         try:
-            data = await self._query(domain)
+            data = await self._query(domain, client=client)
             return self._extract_org(data)
         except Exception as exc:
             inc(SOURCE_ERRORS_TOTAL, source="rdap")
             log.warning("rdap.lookup_failed", domain=domain, error=str(exc))
             return None
 
-    async def get_registrant_info(self, domain: str) -> dict[str, str | None]:
+    async def get_registrant_info(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> dict[str, str | None]:
         """Return a dict with org, name, country from RDAP."""
         try:
-            data = await self._query(domain)
+            data = await self._query(domain, client=client)
         except Exception as exc:
             inc(SOURCE_ERRORS_TOTAL, source="rdap")
             log.warning("rdap.lookup_failed", domain=domain, error=str(exc))
@@ -200,7 +207,18 @@ class RDAPLookup:
             cls._semaphore_loop_id = loop_id
         return cls._semaphore
 
-    async def _query(self, domain: str) -> dict[str, object]:
+    async def _query(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> dict[str, object]:
+        """Fetch RDAP data for ``domain``.
+
+        ``client``: when provided, this caller-owned pooled client (one per
+        scan, #166) is reused with ``follow_redirects``/``timeout`` applied
+        per-request; when ``None``, a per-call client is constructed and
+        closed here (standalone/test path, unchanged). rdap.org 302-redirects
+        to the registry server, so ``follow_redirects=True`` is mandatory on
+        both paths.
+        """
         tld = domain.rsplit(".", 1)[-1].lower()
         if tld in RDAP_SKIP_TLDS:
             log.debug("rdap.skip_unsupported_tld", domain=domain, tld=tld)
@@ -217,13 +235,21 @@ class RDAPLookup:
         async with semaphore:
             try:
                 url = f"{_RDAP_BOOTSTRAP}{domain}"
-                async with httpx.AsyncClient(
-                    timeout=self._cfg.http_timeout,
-                    follow_redirects=True,
-                ) as client:
-                    resp = await client.get(url)
+                data: dict[str, object]
+                if client is not None:
+                    resp = await client.get(
+                        url, follow_redirects=True, timeout=self._cfg.http_timeout
+                    )
                     resp.raise_for_status()
-                    data: dict[str, object] = resp.json()
+                    data = resp.json()
+                else:
+                    async with httpx.AsyncClient(
+                        timeout=self._cfg.http_timeout,
+                        follow_redirects=True,
+                    ) as own_client:
+                        resp = await own_client.get(url)
+                        resp.raise_for_status()
+                        data = resp.json()
                 log.debug("rdap.query_ok", domain=domain)
                 breaker.record_success()
                 return data
@@ -307,7 +333,9 @@ class RDAPLookup:
                     return country
         return None
 
-    async def get_full_info(self, domain: str) -> dict[str, object]:
+    async def get_full_info(
+        self, domain: str, client: httpx.AsyncClient | None = None
+    ) -> dict[str, object]:
         """Return a full RDAP info dict for a domain.
 
         Keys: org, name, country, registrar, created_date, expiry_date,
@@ -315,7 +343,7 @@ class RDAPLookup:
         None values with an empty nameservers list and raw as {}.
         """
         try:
-            data = await self._query(domain)
+            data = await self._query(domain, client=client)
         except Exception as exc:
             inc(SOURCE_ERRORS_TOTAL, source="rdap")
             log.warning("rdap.lookup_failed", domain=domain, error=str(exc))

--- a/domain_scout/tests/test_acceptance.py
+++ b/domain_scout/tests/test_acceptance.py
@@ -7,7 +7,7 @@ Scout level.
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -15,6 +15,9 @@ import pytest
 from domain_scout.config import ScoutConfig
 from domain_scout.models import EntityInput
 from domain_scout.scout import Scout
+
+if TYPE_CHECKING:
+    import httpx
 
 # --- Walmart fixture data ---
 # Simulates CT records from crt.sh for walmart.com seed expansion
@@ -96,17 +99,18 @@ _WALMART_DNS: dict[str, bool] = {
 }
 
 
-def _make_scout() -> Scout:
+def _make_scout(config: ScoutConfig | None = None) -> Scout:
     """Create a Scout with mocked sources."""
-    config = ScoutConfig()
-    scout = Scout(config=config)
+    scout = Scout(config=config or ScoutConfig())
 
     # Mock CT source
-    async def ct_search_by_domain(domain: str) -> list[dict[str, object]]:
+    async def ct_search_by_domain(
+        domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
         return _WALMART_CT_DOMAIN.get(domain, [])
 
     async def ct_search_by_org(
-        org_name: str, *, verify_org: bool = True
+        org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
         return list(_WALMART_CT_ORG)
 
@@ -255,3 +259,43 @@ class TestSeedOnlyDiscovery:
 
         assert result.entity.company_name == ""
         assert result.entity.seed_domain == ["walmart.com"]
+
+
+class TestPhaseErrorsSurfaceInMetadata:
+    """#167: a corroboration-phase fault is recorded in RunMetadata.errors and
+    the scan still returns results (no silent swallow)."""
+
+    @pytest.mark.asyncio
+    async def test_infra_check_failure_recorded_and_scan_continues(self) -> None:
+        scout = _make_scout()
+        scout._dns.shares_infrastructure = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("infra boom")
+        )
+        result = await scout.discover_async(
+            EntityInput(company_name="Walmart", seed_domain=["walmart.com"])
+        )
+
+        # Scan still produced domains despite the boost fault.
+        assert result.domains
+        # The swallowed exception is now visible in the run metadata.
+        assert any("infra check failed" in e for e in result.run_metadata.errors)
+
+    @pytest.mark.asyncio
+    async def test_infra_boost_timeout_recorded_in_metadata(self) -> None:
+        import asyncio
+
+        # Tight budget so the infra phase's caller-owned, budget-derived timeout
+        # (~1s) fires; RDAP corroboration is skipped at this budget.
+        scout = _make_scout(ScoutConfig(total_timeout=2))
+
+        async def hang(_a: str, _b: str) -> bool:
+            await asyncio.sleep(30.0)
+            return False
+
+        scout._dns.shares_infrastructure = AsyncMock(side_effect=hang)  # type: ignore[method-assign]
+        result = await scout.discover_async(
+            EntityInput(company_name="Walmart", seed_domain=["walmart.com"])
+        )
+
+        assert result.domains
+        assert any("Infrastructure boost timed out" in e for e in result.run_metadata.errors)

--- a/domain_scout/tests/test_cache.py
+++ b/domain_scout/tests/test_cache.py
@@ -183,7 +183,7 @@ class TestCachedCTLogSource:
         wrapper = CachedCTLogSource(inner, cache)
         result = await wrapper.search_by_domain("miss.com")
         assert result == fresh_data
-        inner.search_by_domain.assert_called_once_with("miss.com")
+        inner.search_by_domain.assert_called_once_with("miss.com", client=None)
         # Should be cached now
         assert cache.get_ct("domain:miss.com") == fresh_data
 
@@ -243,7 +243,7 @@ class TestCachedRDAPLookup:
         wrapper = CachedRDAPLookup(inner, cache)
         result = await wrapper.get_registrant_org("miss.com")
         assert result == "Fresh Corp"
-        inner.get_registrant_org.assert_called_once_with("miss.com")
+        inner.get_registrant_org.assert_called_once_with("miss.com", client=None)
 
     @pytest.mark.asyncio
     async def test_registrant_info_hit(self, cache: DuckDBCache) -> None:
@@ -266,7 +266,7 @@ class TestCachedRDAPLookup:
         wrapper = CachedRDAPLookup(inner, cache)
         result = await wrapper.get_registrant_info("miss.com")
         assert result == info
-        inner.get_registrant_info.assert_called_once_with("miss.com")
+        inner.get_registrant_info.assert_called_once_with("miss.com", client=None)
 
     @pytest.mark.asyncio
     async def test_cache_write_failure_returns_result(self, cache: DuckDBCache) -> None:

--- a/domain_scout/tests/test_fingerprint.py
+++ b/domain_scout/tests/test_fingerprint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -9,6 +10,9 @@ import pytest
 from domain_scout.config import ScoutConfig
 from domain_scout.models import EntityInput
 from domain_scout.scout import Scout
+
+if TYPE_CHECKING:
+    import httpx
 from domain_scout.sources.dns_fingerprint import (
     DNSFingerprint,
     MXTenant,
@@ -402,11 +406,13 @@ def _make_shelter_scout() -> Scout:
     scout = Scout(config=config)
 
     # Mock CT — DV certs, no org search results
-    async def ct_search_by_domain(domain: str) -> list[dict[str, object]]:
+    async def ct_search_by_domain(
+        domain: str, client: httpx.AsyncClient | None = None
+    ) -> list[dict[str, object]]:
         return _SHELTER_CT_DOMAIN.get(domain, [])
 
     async def ct_search_by_org(
-        org_name: str, *, verify_org: bool = True
+        org_name: str, *, verify_org: bool = True, client: httpx.AsyncClient | None = None
     ) -> list[dict[str, object]]:
         return []  # DV certs — org search finds nothing
 

--- a/domain_scout/tests/test_invariants.py
+++ b/domain_scout/tests/test_invariants.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 import hashlib
 import math
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+
+if TYPE_CHECKING:
+    import httpx
 
 from domain_scout.eval import compute_metrics
 from domain_scout.scout import (
@@ -361,7 +365,10 @@ class TestPhaseOrdering:
             return {d: True for d in domains}
 
         async def mock_rdap_corroborate(
-            domain_evidence: dict[str, _DomainAccum], company_name: str
+            domain_evidence: dict[str, _DomainAccum],
+            company_name: str,
+            errors: list[str] | None = None,
+            client: httpx.AsyncClient | None = None,
         ) -> None:
             call_order.append("rdap_corroborate")
 

--- a/domain_scout/tests/test_multi_seed.py
+++ b/domain_scout/tests/test_multi_seed.py
@@ -829,7 +829,7 @@ class TestRDAPCorroboration:
         a.resolves = True
         evidence["walmart.com"] = a
 
-        await self.scout._rdap_corroborate(evidence, "Walmart")
+        await self.scout._rdap_corroborate(evidence, "Walmart", [])
         assert "rdap_registrant_match" in a.sources
         assert a.rdap_org == "Walmart Inc."
         assert any(e.source_type == "rdap_registrant_match" for e in a.evidence)
@@ -843,7 +843,7 @@ class TestRDAPCorroboration:
         a.resolves = False
         evidence["dead.com"] = a
 
-        await self.scout._rdap_corroborate(evidence, "Walmart")
+        await self.scout._rdap_corroborate(evidence, "Walmart", [])
         assert "rdap_registrant_match" not in a.sources
 
     @pytest.mark.asyncio
@@ -856,7 +856,7 @@ class TestRDAPCorroboration:
         a.resolves = True
         evidence["unrelated.com"] = a
 
-        await self.scout._rdap_corroborate(evidence, "Walmart")
+        await self.scout._rdap_corroborate(evidence, "Walmart", [])
         assert "rdap_registrant_match" not in a.sources
 
     @pytest.mark.asyncio
@@ -872,7 +872,7 @@ class TestRDAPCorroboration:
         evidence["walmart.com"] = a
 
         # Should not raise
-        await self.scout._rdap_corroborate(evidence, "Walmart")
+        await self.scout._rdap_corroborate(evidence, "Walmart", [])
         # Source should NOT be added when RDAP fails
         assert "rdap_registrant_match" not in a.sources
 
@@ -890,5 +890,5 @@ class TestRDAPCorroboration:
             a.resolves = True
             evidence[f"domain{i}.com"] = a
 
-        await self.scout._rdap_corroborate(evidence, "Walmart")
+        await self.scout._rdap_corroborate(evidence, "Walmart", [])
         assert self.scout._rdap.get_registrant_org.call_count == 3

--- a/domain_scout/tests/test_shared_client_and_phase_errors.py
+++ b/domain_scout/tests/test_shared_client_and_phase_errors.py
@@ -1,0 +1,273 @@
+"""Tests for #166 (one pooled httpx client per scan) and #167 (phase errors
+are recorded, not silently swallowed).
+
+#166: RDAP and CT-JSON fetchers reuse a caller-owned client when one is
+injected, and fall back to a per-call client otherwise; a single scan
+constructs exactly one client and closes it.
+
+#167: the infra / rdap / fingerprint corroboration checks record swallowed
+exceptions to the scan error channel (RunMetadata.errors) instead of dropping
+them, and the scan still completes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from domain_scout.config import ScoutConfig
+from domain_scout.models import EntityInput
+from domain_scout.scout import Scout, _DomainAccum
+from domain_scout.sources.ct_logs import CTLogSource
+from domain_scout.sources.rdap import RDAPLookup
+
+
+def _response(json_payload: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = json_payload
+    return resp
+
+
+def _injected_client(json_payload: Any) -> AsyncMock:
+    """A caller-owned client (never used as a context manager in the hot path)."""
+    client = AsyncMock()
+    client.get.return_value = _response(json_payload)
+    return client
+
+
+def _ctx_client(json_payload: Any) -> AsyncMock:
+    """A per-call client mock supporting `async with` (the fallback path)."""
+    client = AsyncMock()
+    client.get.return_value = _response(json_payload)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# #166 — source-level injected client reuse
+# --------------------------------------------------------------------------- #
+
+_RDAP_DATA = {
+    "entities": [
+        {
+            "roles": ["registrant"],
+            "vcardArray": [
+                "vcard",
+                [["version", {}, "text", "4.0"], ["org", {}, "text", "Example Corp"]],
+            ],
+        }
+    ]
+}
+
+
+class TestRDAPInjectedClient:
+    @pytest.mark.asyncio
+    async def test_reuses_injected_client_without_constructing_one(self) -> None:
+        RDAPLookup._breaker = None  # fresh, closed breaker
+        rdap = RDAPLookup(ScoutConfig())
+        injected = _injected_client(_RDAP_DATA)
+
+        with patch("domain_scout.sources.rdap.httpx.AsyncClient") as ctor:
+            org = await rdap.get_registrant_org("example.com", client=injected)
+
+        assert org == "Example Corp"
+        injected.get.assert_awaited_once()
+        # rdap.org 302-redirects to the registry server: follow_redirects must
+        # be applied per-request on the shared client (a MockTransport would
+        # not redirect, so assert it explicitly).
+        _, kwargs = injected.get.call_args
+        assert kwargs.get("follow_redirects") is True
+        # No per-call client constructed when one is injected.
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_own_client_when_none_injected(self) -> None:
+        RDAPLookup._breaker = None
+        rdap = RDAPLookup(ScoutConfig())
+        own = _ctx_client(_RDAP_DATA)
+
+        with patch("domain_scout.sources.rdap.httpx.AsyncClient", return_value=own) as ctor:
+            org = await rdap.get_registrant_org("example.com")
+
+        assert org == "Example Corp"
+        ctor.assert_called_once()  # standalone path still constructs + closes its own
+        own.__aexit__.assert_awaited()
+
+
+class TestCTJSONInjectedClient:
+    _PAYLOAD = [
+        {
+            "id": 1,
+            "common_name": "example.com",
+            "name_value": "example.com\nwww.example.com",
+            "not_before": "2020-01-01T00:00:00",
+            "not_after": "2030-01-01T00:00:00",
+        }
+    ]
+
+    @pytest.mark.asyncio
+    async def test_json_query_reuses_injected_client(self) -> None:
+        CTLogSource._breaker = None
+        ct = CTLogSource(ScoutConfig())
+        injected = _injected_client(self._PAYLOAD)
+
+        with patch("domain_scout.sources.ct_logs.httpx.AsyncClient") as ctor:
+            records = await ct._json_query("example.com", client=injected)
+
+        assert [r["common_name"] for r in records] == ["example.com"]
+        injected.get.assert_awaited_once()
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_json_query_falls_back_to_own_client(self) -> None:
+        CTLogSource._breaker = None
+        ct = CTLogSource(ScoutConfig())
+        own = _ctx_client(self._PAYLOAD)
+
+        with patch("domain_scout.sources.ct_logs.httpx.AsyncClient", return_value=own) as ctor:
+            records = await ct._json_query("example.com")
+
+        assert [r["common_name"] for r in records] == ["example.com"]
+        ctor.assert_called_once()
+        own.__aexit__.assert_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# #166 — one client per scan, shared and closed
+# --------------------------------------------------------------------------- #
+
+
+class TestScanSharesOneClient:
+    @pytest.mark.asyncio
+    async def test_scan_constructs_one_client_shares_it_and_closes_it(self) -> None:
+        scout = Scout(config=ScoutConfig())
+        seen: list[tuple[str, object]] = []
+
+        async def ct_by_domain(domain: str, client: object = None) -> list[dict[str, object]]:
+            seen.append(("ct_domain", client))
+            return []
+
+        async def ct_by_org(
+            org_name: str, *, verify_org: bool = True, client: object = None
+        ) -> list[dict[str, object]]:
+            seen.append(("ct_org", client))
+            return []
+
+        async def rdap_org(domain: str, client: object = None) -> str | None:
+            seen.append(("rdap", client))
+            return None
+
+        scout._ct.search_by_domain = AsyncMock(side_effect=ct_by_domain)  # type: ignore[method-assign]
+        scout._ct.search_by_org = AsyncMock(side_effect=ct_by_org)  # type: ignore[method-assign]
+        scout._rdap.get_registrant_org = AsyncMock(side_effect=rdap_org)  # type: ignore[method-assign]
+        scout._dns.resolves = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        scout._dns.bulk_resolve = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        fake = AsyncMock()
+        fake.__aenter__ = AsyncMock(return_value=fake)
+        fake.__aexit__ = AsyncMock(return_value=False)
+        ctor = MagicMock(return_value=fake)
+
+        with patch("domain_scout.scout.httpx.AsyncClient", ctor):
+            await scout.discover_async(EntityInput(company_name="TestCo", seed_domain=["test.com"]))
+
+        # Exactly one client per scan.
+        assert ctor.call_count == 1
+        # Sources were invoked, all with the same shared client instance.
+        assert seen
+        assert all(client is fake for _, client in seen)
+        # Client closed after the scan (async with exit).
+        fake.__aexit__.assert_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# #167 — corroboration checks record errors instead of swallowing them
+# --------------------------------------------------------------------------- #
+
+
+def _candidate(confidence: float = 0.5, *, resolves: bool = True) -> _DomainAccum:
+    accum = _DomainAccum()
+    accum.confidence = confidence
+    accum.resolves = resolves
+    accum.sources.add("ct_org_match")
+    return accum
+
+
+class TestPhaseCheckErrorsRecorded:
+    @pytest.mark.asyncio
+    async def test_infra_boost_records_check_error_and_continues(self) -> None:
+        scout = Scout(config=ScoutConfig())
+        scout._dns.shares_infrastructure = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("shares boom")
+        )
+        evidence = {"candidate.com": _candidate()}
+        errors: list[str] = []
+
+        # Must not raise — a boost-check fault is best-effort.
+        await scout._infra_boost("reference.com", evidence, errors)
+
+        assert any("candidate.com" in e for e in errors)
+        assert "shared_infra" not in evidence["candidate.com"].sources
+
+    @pytest.mark.asyncio
+    async def test_rdap_corroborate_records_check_error(self) -> None:
+        # In production get_registrant_org swallows RDAP faults internally and
+        # returns None, so the _check except fires only on a genuine post-lookup
+        # fault (parser/cache bug). This mocks that by making the call raise.
+        scout = Scout(config=ScoutConfig())
+        scout._rdap.get_registrant_org = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("rdap boom")
+        )
+        evidence = {"x.com": _candidate()}
+        errors: list[str] = []
+
+        await scout._rdap_corroborate(evidence, "X Corp", errors)
+
+        assert any("x.com" in e for e in errors)
+        assert "rdap_registrant_match" not in evidence["x.com"].sources
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_corroborate_records_check_error(self) -> None:
+        scout = Scout(config=ScoutConfig(discovery_mode="fingerprint"))
+
+        seed_fp = MagicMock()
+        seed_fp.has_signals = True
+        seed_fp.mx_tenants = []
+        seed_fp.ns_zones = []
+        seed_fp.ip_prefixes = []
+        seed_fp.spf_includes = []
+
+        async def fake_extract(domain: str, _dns: object) -> object:
+            if domain == "seed.com":
+                return seed_fp
+            raise RuntimeError("fingerprint boom")
+
+        evidence = {"candidate.com": _candidate()}
+        errors: list[str] = []
+
+        with patch("domain_scout.scout.extract_fingerprint", side_effect=fake_extract):
+            await scout._fingerprint_corroborate(evidence, ["seed.com"], errors)
+
+        assert any("candidate.com" in e for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_seed_extraction_error_recorded(self) -> None:
+        # A seed-extraction fault must surface on the error channel rather than
+        # being masked as "no seed signals" (#167 seed-side symmetry).
+        scout = Scout(config=ScoutConfig(discovery_mode="fingerprint"))
+
+        async def fake_extract(_domain: str, _dns: object) -> object:
+            raise RuntimeError("seed fingerprint boom")
+
+        evidence = {"candidate.com": _candidate()}
+        errors: list[str] = []
+
+        with patch("domain_scout.scout.extract_fingerprint", side_effect=fake_extract):
+            await scout._fingerprint_corroborate(evidence, ["seed.com"], errors)
+
+        assert any("seed.com" in e for e in errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "certifi>=2024.7.4",
     "dnspython>=2.7.0",
     "httpx>=0.28.0",
     "psycopg2-binary>=2.9.11",

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,7 @@ name = "domain-scout-ct"
 version = "0.11.0"
 source = { editable = "." }
 dependencies = [
+    { name = "certifi" },
     { name = "dnspython" },
     { name = "httpx" },
     { name = "psycopg2-binary" },
@@ -269,6 +270,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2024.7.4" },
     { name = "dnspython", specifier = ">=2.7.0" },
     { name = "domain-scout-ct", extras = ["api", "cache", "gleif", "metrics", "eval"], marker = "extra == 'all'" },
     { name = "duckdb", marker = "extra == 'cache'", specifier = ">=1.0.0" },


### PR DESCRIPTION
Closes #166. Closes #167.

## What / why

Two related resource/observability fixes, no scoring-logic change:

- **#166** — every HTTP request built and tore down its own `httpx.AsyncClient` (RDAP once per candidate against rdap.org, CT JSON per fallback, GeoDNS per phase). Now one pooled client per scan.
- **#167** — the infra/rdap/fingerprint corroboration phases swallowed per-check exceptions (bare `except Exception: pass` in `_infra_boost`, silent `return` in `_fingerprint_corroborate`), so a systematic fault read as "no signal found". Now recorded; timeouts made consistent.

## How

### #166 — one pooled client per scan
- `Scout._discover` opens a single `async with httpx.AsyncClient(verify=_SSL_CONTEXT, timeout=http_timeout)` and delegates to a new `_run_pipeline(entity, scan_client)` (thin lifecycle owner / worker split, so the body isn't mass-reindented — review with `git diff -w`).
- The client is threaded to the RDAP and CT sources as an optional `client=` kwarg (mirrors the ds-api PR #72/#74 injected-with-fallback idiom). When `client is None`, each fetcher constructs+closes its own client — standalone/test behavior unchanged. The `CTSource`/`RDAPSource` protocols and all implementations (CTLogSource, Cached*, Hybrid, LocalParquet, CTScoutRemote, RDAPLookup) accept `client=`; LocalParquet (DuckDB) and CTScoutRemote (own host/keyed client) accept-and-ignore it.
- `_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())` built once at import — matches httpx's own default trust anchors (httpx uses certifi) while keeping per-scan construction cheap.
- **Scoped to the scan, not stored on the instance + closed in `Scout.close()`** as the task's wording suggested: `Scout.discover()` runs `asyncio.run` per call, so a persistent client would risk cross-event-loop reuse — the exact hazard #166 calls out ("don't cache clients at class level the way the RDAP semaphore is loop-guarded"). `async with` closes it deterministically at scan end; `Scout.close()` has no persistent client to reap.

### #167 — record swallowed errors; consistent timeouts
- New `_record_check_error(phase, domain, exc, errors)` helper: `log.debug` + `inc(SOURCE_ERRORS_TOTAL, source=phase)` + append to the scan `errors` list (→ `RunMetadata.errors`). Wired into all three corroboration `_check` bodies **and** the seed-side fingerprint extraction (previously debug-logged only), so a fault surfaces symmetrically instead of collapsing to "no seed signals".
- Timeouts: all three phases are now **caller-owned, budget-derived** `asyncio.wait_for` wrappers with `except TimeoutError: errors.append(...)` — the idiom the fingerprint phase already documented. Removed the redundant inner `wait_for(15.0)` in `_rdap_corroborate` and the inner `wait_for(10.0)` in `_infra_boost` (which hardcoded 10s and swallowed its timeout without recording it). No bare `except Exception: pass` remains in scout.py.

## Gate (ran exactly this, exit 0)

`make check` → `ruff check` clean, `ruff format --check` clean, `mypy domain_scout/ --ignore-missing-imports` = no issues (51 files, all extras installed), `pytest -m "not integration"` = **774 passed**, coverage **94.28%** (≥92 required). New test file at 100%. The identical pre-existing missing-stub / `reset()`-warning baseline was confirmed on `main` by stash-compare.

**No-leak evidence (#166 acceptance criterion):** across all 774 tests (many construct real clients), zero `Unclosed <httpx.AsyncClient>` warnings; the only ResourceWarnings (unclosed socket/event-loop) are byte-identical on the base commit.

## Pre-PR adversarial self-review (synchronous pass on the final diff)

One reviewer pass ran on the final diff, focused on lifecycle leaks + error-swallow regressions. Findings addressed pre-push:
- **(F1) SSL trust anchors** — a bare `ssl.create_default_context()` uses the system OpenSSL store; httpx's default uses certifi. Fixed to `cafile=certifi.where()` to preserve the old trust anchors exactly (certifi promoted to a declared dependency).
- **(F2) seed-side fingerprint swallow** — the candidate side was fixed but seed extraction still debug-dropped; now routed through `_record_check_error` too (with a covering test).
- **(F3) tautological timeout test removed** — replaced by the real-budget acceptance test `test_infra_boost_timeout_recorded_in_metadata`.
- **(F6) `errors` made required on all three phases** for consistency (dropped a dead `None`-normalize branch).

**(a) Clever/leftover?** No — no drafting aliases/dead branches/debug prints; the `_discover`/`_run_pipeline` split is the lifecycle seam, not churn-avoidance.
**(b) Claims verifiable?** The gate command is `make check` verbatim; the 774/94.28% and 51-file mypy counts are from that run's output.
**(c) Matches existing patterns?** `client=` optional-kwarg threading mirrors the existing `config: ScoutConfig | None` pattern and ds-api #72; the caller-owned `wait_for` + `errors.append` idiom matches the pre-existing RDAP/fingerprint callers; error-recording style matches `_validate_seed`'s existing `errors.append(f"... for {seed}: {exc}")`.
**(d) Design gates / symptom-patch?** #167 is itself the root-cause observability fix (Gate-3-adjacent: it ships drift/fault *detection* for silently-swallowed corroboration failures). Not a symptom-patch; no follow-up issue to file.

## Residual risks
1. **Scan status flip** — a genuine corroboration-check fault now appends to `RunMetadata.errors`, flipping `SCANS_TOTAL` status ok→error. Intended (#167) and consistent with the existing channel (`_validate_seed` already appends "RDAP lookup failed"); the DNS layer swallows benign misses internally, so this fires only on real faults (no flooding).
2. **GeoDNS timeout** now tracks `http_timeout` (15 default → byte-identical) instead of a hardcoded 15s; diverges only if `http_timeout` is customized, and only on the deep-mode-only GeoDNS path.
3. **CT-JSON sharing** benefits the cold Postgres-fallback path only; the hot win is RDAP corroboration.

## Deploy note
Orchestrator: pull + restart `domain-scout-api` after merge — it imports this repo editable, so the shared-client change ships on restart. Standard runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4
