### PR TITLE
Harden source singletons; per-module mypy; single Docker sync (#172 #168 #173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run mypy domain_scout/ --ignore-missing-imports
+      - run: uv run mypy domain_scout/
 
   test:
     needs: changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md LICENSE ./
 # Install dependencies only (cached layer — invalidated only when deps change)
 RUN uv sync --no-dev --frozen --all-extras --no-editable --no-install-project
-# Copy source and build the project
+# Copy source and install ONLY the project into the cached dependency venv (#173).
+# Deps are already satisfied by the layer above and are unchanged on source-only
+# edits, so this step never re-resolves or reinstalls third-party packages.
 COPY domain_scout/ domain_scout/
-RUN uv sync --no-dev --frozen --all-extras --no-editable
+RUN uv pip install --python /app/.venv --no-deps .
 
 # Runtime stage
 FROM python:3.12-slim

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test-integration:
 
 lint:
 	uv run ruff check domain_scout/
-	uv run mypy domain_scout/ --ignore-missing-imports
+	uv run mypy domain_scout/
 
 format:
 	uv run ruff check --fix domain_scout/

--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -6,7 +6,7 @@ import asyncio
 import re
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import httpx
 import psycopg2
@@ -224,25 +224,40 @@ class _CircuitBreaker:
 
 
 class CTLogSource:
-    """Query crt.sh for certificate transparency data."""
+    """Query crt.sh for certificate transparency data.
 
-    _breaker: _CircuitBreaker | None = None
+    The Postgres circuit breaker protects crt.sh as a shared external resource,
+    so it is shared process-wide across instances. To keep behaviour deterministic
+    and independent of construction order (#172), breakers live in a class-level
+    registry keyed by their ``(failure_threshold, recovery_timeout)`` parameters:
+    instances built from the same config share one breaker; instances with
+    different thresholds get their own (each still trips independently on
+    crt.sh failures).
+    """
+
+    # Shared breakers keyed by (failure_threshold, recovery_timeout).
+    _breakers: ClassVar[dict[tuple[int, float], _CircuitBreaker]] = {}
 
     def __init__(self, config: ScoutConfig) -> None:
         self._cfg = config
         self._semaphore = asyncio.Semaphore(config.max_concurrent_queries)
-        # Lazily init shared breaker with first instance's config
-        if CTLogSource._breaker is None:
-            CTLogSource._breaker = _CircuitBreaker(
-                config.cb_failure_threshold,
-                config.cb_recovery_timeout,
-            )
+        self._breaker = self._get_breaker(
+            config.cb_failure_threshold,
+            config.cb_recovery_timeout,
+        )
 
-    @property
-    def _active_breaker(self) -> _CircuitBreaker:
-        if self._breaker is None:
-            raise RuntimeError("CTLogSource used before breaker initialization")
-        return self._breaker
+    @classmethod
+    def _get_breaker(cls, failure_threshold: int, recovery_timeout: float) -> _CircuitBreaker:
+        """Return the process-wide breaker for these parameters, creating it once."""
+        key = (failure_threshold, recovery_timeout)
+        breaker = cls._breakers.get(key)
+        if breaker is None:
+            # setdefault so a concurrent constructor (the API builds Scout in a
+            # thread pool) still converges on one shared breaker per key.
+            breaker = cls._breakers.setdefault(
+                key, _CircuitBreaker(failure_threshold, recovery_timeout)
+            )
+        return breaker
 
     # --- Public API ---
 
@@ -431,7 +446,7 @@ class CTLogSource:
 
         ``client``: optional caller-owned pool (#166) threaded to the JSON fallback.
         """
-        breaker = self._active_breaker
+        breaker = self._breaker
 
         if not breaker.should_allow():
             log.warning("ct.circuit_breaker_skip_pg", state=breaker.state)

--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import httpx
 import structlog
@@ -130,35 +130,52 @@ class _RDAPCircuitBreaker:
 class RDAPLookup:
     """Look up domain registration data via RDAP.
 
-    The circuit breaker and semaphore are class-level singletons, initialized
-    from the first instance's config. Subsequent instances reuse the same state.
+    rdap.org is a single shared external resource, so both the circuit breaker
+    and the concurrency semaphore are shared process-wide rather than per-scan.
+    To keep behaviour deterministic and independent of construction order (#172):
+
+    - Breakers live in a class-level registry keyed by their
+      ``(failure_threshold, recovery_timeout)`` parameters. Instances built from
+      the same config share one breaker; differing thresholds get their own
+      (each still trips independently on rdap.org failures).
+    - The semaphore is a single per-event-loop rate limiter — one global cap on
+      concurrent rdap.org requests, never the sum of per-scan caps. It is sized
+      from the config of whichever instance first uses it on a given loop and is
+      recreated when the loop changes (``Scout.discover`` runs ``asyncio.run``
+      per call, so the CLI gets a fresh, correctly-sized semaphore per scan;
+      concurrent scans on the API's shared loop share one cap). Profiles do not
+      vary ``max_rdap_concurrent``, so this is deterministic in practice.
     """
 
-    # Shared across all instances to protect rdap.org as a single resource.
-    # Initialized once from the first instance's config; subsequent instances
-    # log a warning if their config differs.
-    _breaker: _RDAPCircuitBreaker | None = None
-    _semaphore: asyncio.Semaphore | None = None
-    _semaphore_loop_id: int | None = None
-    _init_concurrency: int | None = None
+    # Shared breakers keyed by (failure_threshold, recovery_timeout).
+    _breakers: ClassVar[dict[tuple[int, float], _RDAPCircuitBreaker]] = {}
+    # Single per-loop shared semaphore (created lazily in the running loop).
+    _semaphore: ClassVar[asyncio.Semaphore | None] = None
+    _semaphore_loop_id: ClassVar[int | None] = None
 
     def __init__(self, config: ScoutConfig) -> None:
         self._cfg = config
-        # Store concurrency for _ensure_semaphore (semaphore created lazily
-        # in the correct event loop, not here).
-        if RDAPLookup._init_concurrency is None:
-            RDAPLookup._init_concurrency = config.max_rdap_concurrent
-        elif RDAPLookup._init_concurrency != config.max_rdap_concurrent:
-            log.warning(
-                "rdap.config_mismatch_ignored",
-                existing=RDAPLookup._init_concurrency,
-                requested=config.max_rdap_concurrent,
+        self._breaker = self._get_breaker(
+            config.rdap_cb_failure_threshold,
+            config.rdap_cb_recovery_timeout,
+        )
+
+    @classmethod
+    def _get_breaker(cls, failure_threshold: int, recovery_timeout: float) -> _RDAPCircuitBreaker:
+        """Return the process-wide breaker for these parameters, creating it once."""
+        key = (failure_threshold, recovery_timeout)
+        breaker = cls._breakers.get(key)
+        if breaker is None:
+            # setdefault so a concurrent constructor (the API builds Scout in a
+            # thread pool) still converges on one shared breaker per key.
+            breaker = cls._breakers.setdefault(
+                key,
+                _RDAPCircuitBreaker(
+                    failure_threshold=failure_threshold,
+                    recovery_timeout=recovery_timeout,
+                ),
             )
-        if RDAPLookup._breaker is None:
-            RDAPLookup._breaker = _RDAPCircuitBreaker(
-                failure_threshold=config.rdap_cb_failure_threshold,
-                recovery_timeout=config.rdap_cb_recovery_timeout,
-            )
+        return breaker
 
     async def get_registrant_org(
         self, domain: str, client: httpx.AsyncClient | None = None
@@ -192,20 +209,20 @@ class RDAPLookup:
             "country": self._extract_country(data),
         }
 
-    @classmethod
-    def _ensure_semaphore(cls) -> asyncio.Semaphore:
-        """Ensure semaphore belongs to the current event loop.
+    def _ensure_semaphore(self) -> asyncio.Semaphore:
+        """Return the shared per-loop rdap.org semaphore, sized from this config.
 
-        When Scout.discover() calls asyncio.run() in a loop, each call
+        When Scout.discover() calls asyncio.run() per invocation, each call
         creates a new event loop. A Semaphore from a previous loop raises
-        "bound to a different event loop". Detect this and recreate.
+        "bound to a different event loop", so it is recreated when the loop
+        changes — sized from the current instance's ``max_rdap_concurrent``
+        rather than a value frozen from the first-ever instance (#172).
         """
         loop_id = id(asyncio.get_running_loop())
-        if cls._semaphore is None or cls._semaphore_loop_id != loop_id:
-            concurrency = cls._init_concurrency or 5
-            cls._semaphore = asyncio.Semaphore(concurrency)
-            cls._semaphore_loop_id = loop_id
-        return cls._semaphore
+        if RDAPLookup._semaphore is None or RDAPLookup._semaphore_loop_id != loop_id:
+            RDAPLookup._semaphore = asyncio.Semaphore(self._cfg.max_rdap_concurrent)
+            RDAPLookup._semaphore_loop_id = loop_id
+        return RDAPLookup._semaphore
 
     async def _query(
         self, domain: str, client: httpx.AsyncClient | None = None
@@ -224,9 +241,8 @@ class RDAPLookup:
             log.debug("rdap.skip_unsupported_tld", domain=domain, tld=tld)
             return {}
 
-        breaker = RDAPLookup._breaker
+        breaker = self._breaker
         semaphore = self._ensure_semaphore()
-        assert breaker is not None
 
         if not breaker.should_allow():
             log.warning("rdap.circuit_open_skip", domain=domain)

--- a/domain_scout/tests/conftest.py
+++ b/domain_scout/tests/conftest.py
@@ -3,8 +3,36 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
 
 from domain_scout.models import EntityInput, RunMetadata, ScoutResult
+from domain_scout.sources.ct_logs import CTLogSource
+from domain_scout.sources.rdap import RDAPLookup
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_source_state() -> Iterator[None]:
+    """Reset process-wide breaker/semaphore state shared across source instances.
+
+    The CT/RDAP breakers and the RDAP semaphore are shared class-level state
+    (#172). Clearing it around every test prevents circuit state or a stale
+    event-loop-bound semaphore from bleeding across tests.
+    """
+
+    def _clear() -> None:
+        CTLogSource._breakers.clear()
+        RDAPLookup._breakers.clear()
+        RDAPLookup._semaphore = None
+        RDAPLookup._semaphore_loop_id = None
+
+    _clear()
+    yield
+    _clear()
 
 
 def mock_result() -> ScoutResult:

--- a/domain_scout/tests/test_ct.py
+++ b/domain_scout/tests/test_ct.py
@@ -3,11 +3,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
 import pytest
 from hypothesis import given
@@ -144,13 +140,6 @@ class TestIsValidDomain:
 
 class TestJsonQueryFields:
     """Verify JSON fallback sets correct field values."""
-
-    @pytest.fixture(autouse=True)
-    def _reset_breaker(self) -> Iterator[None]:
-        """Reset the shared breaker to avoid test-ordering issues."""
-        CTLogSource._breaker = None
-        yield
-        CTLogSource._breaker = None
 
     @pytest.mark.asyncio
     async def test_json_org_name_is_none(self) -> None:
@@ -289,13 +278,6 @@ class TestCircuitBreaker:
 class TestCircuitBreakerWiring:
     """Test circuit breaker wired into CTLogSource._pg_query_with_fallback."""
 
-    @pytest.fixture(autouse=True)
-    def _reset_breaker(self) -> Iterator[None]:
-        """Reset the shared class-variable breaker before each test."""
-        CTLogSource._breaker = None
-        yield
-        CTLogSource._breaker = None
-
     @pytest.mark.asyncio
     async def test_breaker_trips_after_threshold_skips_pg(self) -> None:
         """After cb_failure_threshold PG failures, subsequent calls skip PG entirely."""
@@ -376,8 +358,7 @@ class TestCircuitBreakerWiring:
         ):
             # Trip the breaker
             await ct._pg_query_with_fallback("test")
-            assert CTLogSource._breaker is not None
-            assert CTLogSource._breaker.state == "open"
+            assert ct._breaker.state == "open"
 
             # Advance past recovery timeout
             with patch.object(
@@ -387,7 +368,7 @@ class TestCircuitBreakerWiring:
             ):
                 result = await ct._pg_query_with_fallback("test")
 
-            assert CTLogSource._breaker.state == "closed"
+            assert ct._breaker.state == "closed"
             assert result[0]["cert_id"] == 42
 
     @pytest.mark.asyncio
@@ -421,8 +402,9 @@ class TestCircuitBreakerWiring:
             patch("domain_scout.sources.ct_logs.httpx.AsyncClient", return_value=mock_json),
         ):
             await ct1._pg_query_with_fallback("test")
-            assert CTLogSource._breaker is not None
-            assert CTLogSource._breaker.state == "open"
+            # Same config → both instances resolve to the one registry breaker.
+            assert ct1._breaker is ct2._breaker
+            assert ct1._breaker.state == "open"
 
         # ct2 should also see the open breaker (shared class variable)
         pg_called = False
@@ -459,13 +441,6 @@ class TestOrgSearchFallbackUnavailable:
         }
     ]
 
-    @pytest.fixture(autouse=True)
-    def _reset_breaker(self) -> Iterator[None]:
-        """Reset the shared breaker to avoid test-ordering issues."""
-        CTLogSource._breaker = None
-        yield
-        CTLogSource._breaker = None
-
     @pytest.mark.asyncio
     async def test_pg_failure_verify_org_raises_without_json_query(self) -> None:
         """Postgres failure + verify_org=True raises and never queries the JSON API."""
@@ -485,9 +460,8 @@ class TestOrgSearchFallbackUnavailable:
         """Circuit-breaker skip + verify_org=True raises; neither backend is queried."""
         config = ScoutConfig(cb_failure_threshold=1, postgres_max_retries=1, burst_delay=0.0)
         ct = CTLogSource(config)
-        assert CTLogSource._breaker is not None
-        CTLogSource._breaker.record_failure()  # threshold=1 → trips open
-        assert CTLogSource._breaker.state == "open"
+        ct._breaker.record_failure()  # threshold=1 → trips open
+        assert ct._breaker.state == "open"
 
         with (
             patch.object(ct, "_pg_query", new_callable=AsyncMock) as pg_query,

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -392,20 +392,6 @@ class TestRDAPCircuitBreaker:
 class TestRDAPRateLimiting:
     """Tests for RDAP semaphore and circuit breaker integration."""
 
-    def setup_method(self) -> None:
-        """Reset class-level state between tests."""
-        RDAPLookup._breaker = None
-        RDAPLookup._semaphore = None
-        RDAPLookup._semaphore_loop_id = None
-        RDAPLookup._init_concurrency = None
-
-    def teardown_method(self) -> None:
-        """Clean up class-level state after each test."""
-        RDAPLookup._breaker = None
-        RDAPLookup._semaphore = None
-        RDAPLookup._semaphore_loop_id = None
-        RDAPLookup._init_concurrency = None
-
     @pytest.mark.asyncio
     async def test_circuit_breaker_skips_when_open(self) -> None:
         """When breaker is open, _query returns empty dict without HTTP call."""
@@ -436,8 +422,7 @@ class TestRDAPRateLimiting:
             for _ in range(3):
                 await rdap.get_registrant_org("missing.com")
 
-            assert RDAPLookup._breaker is not None
-            assert RDAPLookup._breaker.state == "closed"
+            assert rdap._breaker.state == "closed"
 
     @pytest.mark.asyncio
     async def test_5xx_trips_circuit_breaker(self) -> None:
@@ -450,8 +435,7 @@ class TestRDAPRateLimiting:
             await rdap.get_registrant_org("fail1.com")
             await rdap.get_registrant_org("fail2.com")
 
-            assert RDAPLookup._breaker is not None
-            assert RDAPLookup._breaker.state == "open"
+            assert rdap._breaker.state == "open"
 
     @pytest.mark.asyncio
     async def test_class_level_breaker_shared(self) -> None:
@@ -465,18 +449,19 @@ class TestRDAPRateLimiting:
             await rdap1.get_registrant_org("fail1.com")
             await rdap2.get_registrant_org("fail2.com")
 
-            # Two failures across different instances should trip the shared breaker
-            assert RDAPLookup._breaker is not None
-            assert RDAPLookup._breaker.state == "open"
+            # Same config → both instances resolve to the one registry breaker,
+            # so two failures across instances trip the shared breaker.
+            assert rdap1._breaker is rdap2._breaker
+            assert rdap1._breaker.state == "open"
 
     def test_init_does_not_create_semaphore(self) -> None:
         """Semaphore is created lazily in _ensure_semaphore, not __init__."""
         config = ScoutConfig(max_rdap_concurrent=2)
-        RDAPLookup(config)
+        rdap = RDAPLookup(config)
         # Semaphore should NOT be created in __init__ — it must be created
-        # in the correct event loop by _ensure_semaphore.
+        # in the correct event loop by _ensure_semaphore, sized from this config.
         assert RDAPLookup._semaphore is None
-        assert RDAPLookup._init_concurrency == 2
+        assert rdap._cfg.max_rdap_concurrent == 2
 
     @pytest.mark.asyncio
     async def test_semaphore_bound_to_current_loop(self) -> None:
@@ -601,14 +586,6 @@ class TestExtractNameservers:
 
 class TestGetFullInfo:
     """Tests for RDAPLookup.get_full_info()."""
-
-    def setup_method(self) -> None:
-        RDAPLookup._breaker = None
-        RDAPLookup._semaphore = None
-
-    def teardown_method(self) -> None:
-        RDAPLookup._breaker = None
-        RDAPLookup._semaphore = None
 
     @pytest.mark.asyncio
     async def test_success_all_fields(self) -> None:

--- a/domain_scout/tests/test_shared_client_and_phase_errors.py
+++ b/domain_scout/tests/test_shared_client_and_phase_errors.py
@@ -68,7 +68,6 @@ _RDAP_DATA = {
 class TestRDAPInjectedClient:
     @pytest.mark.asyncio
     async def test_reuses_injected_client_without_constructing_one(self) -> None:
-        RDAPLookup._breaker = None  # fresh, closed breaker
         rdap = RDAPLookup(ScoutConfig())
         injected = _injected_client(_RDAP_DATA)
 
@@ -87,7 +86,6 @@ class TestRDAPInjectedClient:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_own_client_when_none_injected(self) -> None:
-        RDAPLookup._breaker = None
         rdap = RDAPLookup(ScoutConfig())
         own = _ctx_client(_RDAP_DATA)
 
@@ -112,7 +110,6 @@ class TestCTJSONInjectedClient:
 
     @pytest.mark.asyncio
     async def test_json_query_reuses_injected_client(self) -> None:
-        CTLogSource._breaker = None
         ct = CTLogSource(ScoutConfig())
         injected = _injected_client(self._PAYLOAD)
 
@@ -125,7 +122,6 @@ class TestCTJSONInjectedClient:
 
     @pytest.mark.asyncio
     async def test_json_query_falls_back_to_own_client(self) -> None:
-        CTLogSource._breaker = None
         ct = CTLogSource(ScoutConfig())
         own = _ctx_client(self._PAYLOAD)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,21 @@ required-imports = ["from __future__ import annotations"]
 strict = true
 python_version = "3.12"
 
+# Per-module import suppression replaces the global --ignore-missing-imports
+# flag (#168), which silently treated *every* unresolved import as Any and
+# undermined strict mode. Only modules that genuinely ship no type stubs are
+# listed here, so a new untyped dependency (or a typo'd import) is still caught.
+# duckdb and tldextract are deliberately NOT listed: they ship types now and
+# are really type-checked once the global flag is gone.
+[[tool.mypy.overrides]]
+module = [
+    "psycopg2.*",     # crt.sh Postgres driver — no bundled stubs / py.typed marker
+    "pyarrow.*",      # Arrow/Parquet (test_local_parquet) — no py.typed marker
+    "shared",         # optional monorepo reference lib, imported only when present (test_matching)
+    "shared.*",       # (both the package and its submodules — it is absent, not merely untyped)
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "--cov=domain_scout --cov-fail-under=92"
 markers = [


### PR DESCRIPTION
One hygiene PR closing three issues. Built on `main` after #189 (shared per-scan client).

## #172 — class-level singletons no longer freeze on first-instance config (the real one)

**Before:** `CTLogSource._breaker`, `RDAPLookup._breaker`, `_semaphore`, `_init_concurrency` were class vars seeded from whichever instance was constructed **first**. In the API a `strict`-profile `/scan` and a `broad` one shared breaker thresholds / concurrency decided by request arrival order (unreproducible), and later instances only logged `rdap.config_mismatch_ignored`.

**After (issue option (b), registry-keyed — see below for why not (a)):**
- **Breakers (CT + RDAP)** live in a class-level registry `dict` keyed by `(failure_threshold, recovery_timeout)`. Same config → one shared breaker (crt.sh/rdap.org still get process-wide protection); different config → its own breaker (each still trips independently). Deterministic, order-independent, and `RunMetadata.config` snapshots are now truthful because each config's breaker uses that config's thresholds.
- **RDAP semaphore** stays a **single per-event-loop** shared rate limiter — one global cap on concurrent rdap.org requests, deliberately **not** config-keyed (config-keying would let two profiles sum their caps against rdap.org, i.e. `N₁+N₂`). It is now sized from the constructing instance's `max_rdap_concurrent` instead of a class-frozen value, and recreated when the loop changes (`Scout.discover` runs `asyncio.run` per call → CLI gets a fresh correctly-sized semaphore per scan; concurrent scans on the API's shared uvicorn loop share one cap).
- Registry writes use `dict.setdefault`, so a concurrent constructor (the API builds `Scout` in a thread pool via `run_in_executor`) still converges on one shared breaker per key rather than orphaning a racing scan's breaker.
- **Test isolation:** an autouse fixture in `conftest.py` clears `CTLogSource._breakers`, `RDAPLookup._breakers`, and the RDAP semaphore state around every test, replacing the scattered `setup_method`/`teardown_method`/`_reset_breaker` resets.

**Why (b) not (a):** the issue author recommended (a) (module-level constants, deprecate the cb config fields). I chose (b) because it keeps the config fields tunable and has a far smaller test blast radius (many tests configure thresholds per-`ScoutConfig` and assert the effective behaviour). Tradeoff — (b) dilutes shared-resource protection **when configs differ**: two different threshold tuples get two breakers. This is theoretical here — none of the `broad`/`balanced`/`strict` profiles override any cb/concurrency field, so in practice all scans map to one key.

## #168 — per-module mypy overrides replace the global flag

Dropped `--ignore-missing-imports` from the `Makefile` lint target and `ci.yml`; added narrow overrides in `pyproject.toml` for exactly the untyped/absent imports the audit found: `psycopg2.*`, `pyarrow.*`, `shared` + `shared.*` (optional monorepo reference lib). **Modules that gain real type-checking now that the global suppressor is gone: `duckdb` and `tldextract`** — both ship types today, so mypy checks their usage instead of treating them as `Any`. `mypy --strict` is 0 errors (51 files, clean cache).

## #173 — Dockerfile installs the project once

Second `uv sync` → `uv pip install --python /app/.venv --no-deps .`. The two-stage cache is preserved: the deps layer (`uv sync … --no-install-project`) is unchanged on source-only edits. Verified with `docker build`: a source-only change leaves the dependency layer **CACHED** and reinstalls exactly 1 package (the project); `domain-scout --help` runs in the image (exit 0).

## Verification (commands run, exit codes confirmed)
- `make check` → **774 passed, 4 deselected**, coverage **94.29%** (gate ≥92).
- `uv run mypy domain_scout/` (clean cache) → `Success: no issues found in 51 source files`.
- `ruff check` + `ruff format --check` → clean.
- `docker build` cold + warm → warm rebuild caches deps, installs project only; CLI smoke test exit 0.

## Self-review
- **(a) Clever/leftover?** Removed the now-trivial `_active_breaker` passthrough property (its old `None`-guard is obsolete) and inlined it to `self._breaker`. No dead branches or debug leftovers.
- **(b) Claims verifiable?** The counts/coverage above are from the exact commands run in this branch, not from memory.
- **(c) Matches existing patterns?** `_get_breaker` is symmetric across `ct_logs.py` and `rdap.py`; `ClassVar` typing matches the strict-mode style; the autouse-reset-in-conftest mirrors the module-singleton test-reset convention.
- **(d) Design gates:** touches gate 1 (overloaded class-var state carrying first-wins config) — resolved at root, not symptom-patched; no money/data totals involved; no filed-issue debt left open.

## Residual risks
- Two pre-existing `AsyncMock … never awaited` warnings in `test_subsidiary.py` (untouched by this PR).
- `id(loop)`-reuse in the RDAP semaphore recreate is unchanged from the prior implementation (pre-existing, not a regression); a freed loop's id being reused could in theory hand back a stale semaphore — not observed and out of scope.
- The (b) dilution note above: if a future request explicitly overrides `max_rdap_concurrent`/cb thresholds per `/scan`, concurrent differing configs would get separate breakers and (for the semaphore) the first config on the shared loop sets the cap. Documented in the `RDAPLookup` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4
