### PR TITLE
Harden get_app env/cache; regression-test breaker registry (#169 #191)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -250,6 +250,24 @@ Configure server-wide defaults so clients don't need to pass paths per request:
 | `DOMAIN_SCOUT_CACHE_DIR` | DuckDB cache directory | System default |
 | `DOMAIN_SCOUT_MAX_CONCURRENT` | Max concurrent scans | `3` |
 
+A non-numeric `DOMAIN_SCOUT_MAX_CONCURRENT` logs a warning and falls back to the
+default (`3`) rather than failing startup.
+
+### Multiple workers and the cache (single-writer)
+
+DuckDB is single-writer: only one process may open `cache.db` for writing.
+`domain-scout serve --workers N` (N > 1) disables the cache automatically. If you
+instead run the uvicorn factory directly with multiple workers:
+
+```bash
+uvicorn domain_scout.api:get_app --workers 4
+```
+
+each worker calls the factory and tries to open `cache.db`. The first wins; the
+others detect the lock conflict, log `api.cache_disabled_lock_conflict`, and
+start cache-less instead of crash-looping or corrupting the file. To disable the
+cache explicitly (and silence the warning), set `DOMAIN_SCOUT_CACHE=false`.
+
 Example deployment with warehouse:
 
 ```bash

--- a/domain_scout/_metrics.py
+++ b/domain_scout/_metrics.py
@@ -67,9 +67,21 @@ if _ENABLED:
         "domain_scout_ct_fallbacks_total",
         "Total CT JSON API fallbacks",
     )
+    # Dilution note (#191): this is a single unlabeled gauge, but the CT source
+    # keeps a registry of breakers keyed by (failure_threshold, recovery_timeout)
+    # — instances with different configs get independent breakers. Every breaker
+    # writes this one gauge, so with multiple concurrent breakers it reflects
+    # whichever transitioned *last*, not any specific breaker. In practice a
+    # process runs a single breaker config (the default), so the dilution is
+    # inert; it only surfaces under mixed configs (mostly tests). Labeling by
+    # config key is deliberately deferred: it would change this metric's series
+    # contract (breaking existing unlabeled dashboards) for a scenario that does
+    # not occur in normal deployments.
     CT_CIRCUIT_BREAKER_STATE = Gauge(
         "domain_scout_ct_circuit_breaker_state",
-        "Circuit breaker state (0=closed, 1=open, 2=half_open)",
+        "Circuit breaker state (0=closed, 1=open, 2=half_open). "
+        "Single gauge shared by all breakers; reflects the last transition "
+        "if multiple breaker configs are active in one process (see #191).",
     )
     SOURCE_ERRORS_TOTAL = Counter(
         "domain_scout_source_errors_total",
@@ -110,5 +122,11 @@ def set_gauge(gauge: Any, value: float) -> None:
 
 
 def set_cb_state(state: str) -> None:
-    """Update the circuit breaker state gauge."""
+    """Update the circuit breaker state gauge.
+
+    Note: ``CT_CIRCUIT_BREAKER_STATE`` is a single unlabeled gauge. When more
+    than one breaker config is active in a process, each breaker's transition
+    overwrites it, so the exported value tracks the most recent transition
+    across all breakers rather than any one breaker (#191).
+    """
     set_gauge(CT_CIRCUIT_BREAKER_STATE, _CB_STATE_MAP.get(state, -1))

--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -27,6 +27,16 @@ from domain_scout.delta import compute_delta
 from domain_scout.models import DeltaReport, EntityInput, ScoutResult
 from domain_scout.scout import Scout
 
+try:
+    import duckdb
+
+    # DuckDB raises IOException when another process already holds the write
+    # lock on cache.db (e.g. a second uvicorn worker). Catch it to enforce the
+    # single-writer constraint gracefully instead of crash-looping (#169).
+    _CACHE_LOCK_ERRORS: tuple[type[Exception], ...] = (duckdb.IOException,)
+except ImportError:  # pragma: no cover - duckdb is an optional [cache] extra
+    _CACHE_LOCK_ERRORS = ()
+
 log = structlog.get_logger()
 
 _VERSION = _pkg_version("domain-scout-ct")
@@ -263,18 +273,41 @@ def create_app(
 def get_app() -> FastAPI:
     """Factory for default app (used by uvicorn import string).
 
-    Note: DuckDB is single-writer. The CLI ``serve`` command disables cache
-    when ``--workers > 1``.  If you call ``uvicorn domain_scout.api:get_app``
-    directly with multiple workers, set ``DOMAIN_SCOUT_CACHE=false``.
+    DuckDB is single-writer, so only one process may open ``cache.db`` for
+    writing. This factory hardens the two documented foot-guns (#169):
+
+    * **Multi-worker cache.** The CLI ``serve`` command disables the cache when
+      ``--workers > 1``. If you instead run ``uvicorn domain_scout.api:get_app``
+      directly with multiple workers, each worker calls this factory; the first
+      opens ``cache.db`` and the rest hit a DuckDB lock conflict. Rather than
+      crash-loop, a worker that loses the race logs
+      ``api.cache_disabled_lock_conflict`` and starts cache-less. Set
+      ``DOMAIN_SCOUT_CACHE=false`` to disable the cache explicitly and silence
+      the warning.
+    * **Bad env values.** A non-numeric ``DOMAIN_SCOUT_MAX_CONCURRENT`` logs a
+      warning and falls back to the default (3) instead of crashing at startup.
     """
-    max_concurrent = int(os.environ.get("DOMAIN_SCOUT_MAX_CONCURRENT", "3"))
+    raw_max_concurrent = os.environ.get("DOMAIN_SCOUT_MAX_CONCURRENT", "3")
+    try:
+        max_concurrent = int(raw_max_concurrent)
+    except ValueError:
+        log.warning("get_app.invalid_max_concurrent_env", value=raw_max_concurrent)
+        max_concurrent = 3
     if max_concurrent < 1:
         log.warning("get_app.invalid_max_concurrent", value=max_concurrent)
         max_concurrent = 1
     cache_enabled = os.environ.get("DOMAIN_SCOUT_CACHE", "true").lower() != "false"
 
     cache_dir = os.environ.get("DOMAIN_SCOUT_CACHE_DIR")
-    cache = DuckDBCache(cache_dir=cache_dir) if cache_enabled else None
+    cache: DuckDBCache | None = None
+    if cache_enabled:
+        try:
+            cache = DuckDBCache(cache_dir=cache_dir)
+        except _CACHE_LOCK_ERRORS as exc:
+            # Another writer already holds cache.db (single-writer constraint).
+            # Degrade to cache-less rather than corrupt the file or crash-loop.
+            log.warning("api.cache_disabled_lock_conflict", error=str(exc))
+            cache = None
 
     api_key = os.environ.get("DOMAIN_SCOUT_API_KEY")
     warehouse_path = os.environ.get("DOMAIN_SCOUT_WAREHOUSE_PATH")

--- a/domain_scout/sources/ct_logs.py
+++ b/domain_scout/sources/ct_logs.py
@@ -163,9 +163,10 @@ class _CircuitBreaker:
     """Simple circuit breaker for crt.sh Postgres connections.
 
     States: closed (normal) → open (skip Postgres) → half_open (probe).
-    Shared across CTLogSource instances via class variable.  The breaker
-    is initialized once from the first CTLogSource instance's config;
-    subsequent instances reuse the same breaker (and its thresholds).
+    Breakers are shared process-wide via the ``CTLogSource._breakers``
+    registry, keyed by ``(failure_threshold, recovery_timeout)``: instances
+    built from the same config share one breaker; instances with different
+    configs get their own, independent of construction order (#172).
     """
 
     def __init__(self, failure_threshold: int, recovery_timeout: float) -> None:

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -250,6 +250,40 @@ class TestGetApp:
             app = get_app()
         assert app.state.default_local_mode == "disabled"
 
+    def test_get_app_invalid_max_concurrent_env_uses_default(self) -> None:
+        """Non-numeric DOMAIN_SCOUT_MAX_CONCURRENT falls back to the default,
+        not an opaque startup crash (#169)."""
+        env = {"DOMAIN_SCOUT_CACHE": "false", "DOMAIN_SCOUT_MAX_CONCURRENT": "abc"}
+        with patch.dict(os.environ, env, clear=False):
+            app = get_app()
+        assert app.state.semaphore._value == 3  # default, startup not prevented
+        assert TestClient(app).get("/health").status_code == 200
+
+    def test_get_app_valid_max_concurrent_env_honored(self) -> None:
+        """A valid DOMAIN_SCOUT_MAX_CONCURRENT is still parsed and applied (#169)."""
+        env = {"DOMAIN_SCOUT_CACHE": "false", "DOMAIN_SCOUT_MAX_CONCURRENT": "7"}
+        with patch.dict(os.environ, env, clear=False):
+            app = get_app()
+        assert app.state.semaphore._value == 7
+
+    def test_get_app_cache_lock_conflict_falls_back_to_cacheless(self) -> None:
+        """A DuckDB write-lock conflict (another worker holds cache.db) degrades
+        to cache=None instead of crashing, enforcing the single-writer
+        constraint for the direct multi-worker uvicorn path (#169)."""
+        duckdb = pytest.importorskip("duckdb")
+
+        def _raise_lock(*args: object, **kwargs: object) -> None:
+            raise duckdb.IOException("Could not set lock on file cache.db")
+
+        env = {"DOMAIN_SCOUT_CACHE": "true"}
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("domain_scout.api.DuckDBCache", _raise_lock),
+        ):
+            app = get_app()
+        assert app.state.cache is None
+        assert TestClient(app).get("/health").status_code == 200
+
 
 class TestScanRequest:
     def test_minimal(self) -> None:

--- a/domain_scout/tests/test_ct.py
+++ b/domain_scout/tests/test_ct.py
@@ -422,6 +422,40 @@ class TestCircuitBreakerWiring:
 
         assert not pg_called  # breaker prevented the call
 
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_different_config_breakers_independent_both_orders(self, reverse: bool) -> None:
+        """Instances with DIFFERENT breaker configs get independent breakers,
+        regardless of construction order (#172, regression #191).
+
+        The pre-#172 first-wins code shared one breaker keyed to whichever
+        instance was built first, so a second instance with different thresholds
+        silently inherited the wrong config. The registry keys by
+        ``(failure_threshold, recovery_timeout)``, so each config trips on its
+        own. Parametrized over both orders because order is exactly what the old
+        bug was sensitive to.
+        """
+        low = ScoutConfig(cb_failure_threshold=1, cb_recovery_timeout=30.0)
+        high = ScoutConfig(cb_failure_threshold=99, cb_recovery_timeout=30.0)
+        order = [high, low] if reverse else [low, high]
+        built = {src._cfg.cb_failure_threshold: src for src in (CTLogSource(c) for c in order)}
+        ct_low, ct_high = built[1], built[99]
+
+        # The defining assertion: distinct breaker objects in EITHER order.
+        # (Old first-wins code would share one object → this fails.)
+        assert ct_low._breaker is not ct_high._breaker
+        assert ct_low._breaker.state == "closed"
+        assert ct_high._breaker.state == "closed"
+
+        # A sub-threshold failure on the high breaker leaks into neither breaker.
+        ct_high._breaker.record_failure()
+        assert ct_high._breaker.state == "closed"
+        assert ct_low._breaker.state == "closed"
+
+        # The low breaker trips on its first failure without perturbing the high one.
+        ct_low._breaker.record_failure()
+        assert ct_low._breaker.state == "open"
+        assert ct_high._breaker.state == "closed"
+
 
 class TestOrgSearchFallbackUnavailable:
     """#163: org search must not silently return zero via the JSON fallback.


### PR DESCRIPTION
Closes #191
Closes #169

Two hardening items shipped together; builds on #189 (shared client) and #190 (breaker registry).

## #169 — harden `get_app()`
- **Env validation:** a non-numeric `DOMAIN_SCOUT_MAX_CONCURRENT` now logs `get_app.invalid_max_concurrent_env` and falls back to the default `3` instead of raising an opaque `ValueError` at factory time. The existing `< 1` clamp is preserved.
- **Single-writer cache:** `DuckDBCache(...)` construction is wrapped so a DuckDB write-lock conflict (another worker already owns `cache.db`) logs `api.cache_disabled_lock_conflict` and degrades to `cache=None` rather than crash-looping or corrupting the file. `_CACHE_LOCK_ERRORS` is built from a guarded `import duckdb` so the base install (no `[cache]` extra) still imports cleanly.
- Docstring + `docs/api.md` deployment section describe the multi-worker behavior and the `DOMAIN_SCOUT_CACHE=false` escape hatch.

Empirically confirmed the real cross-process lock surfaces as `duckdb.IOException` (subprocess holding the lock → second `connect()` raised `_duckdb.IOException`, `isinstance(..., duckdb.IOException) == True`), so the catch targets the right type; the test then stubs that exception deterministically.

## #191 — breaker registry regression test + gauge dilution note
- **Both-orders test** (`test_ct.py`): constructs `cb_failure_threshold=1` and `=99` sources in *both* construction orders (parametrized) and asserts `ct_low._breaker is not ct_high._breaker` — the object-identity assertion that fails on the pre-#172 first-wins code in either order — plus independent state (low trips at 1 failure, high stays closed; a sub-threshold failure on high leaks nowhere).
- **Gauge dilution:** documented on `CT_CIRCUIT_BREAKER_STATE` and `set_cb_state` (chosen over relabeling). Verified no API profile overrides `cb_failure_threshold`/`cb_recovery_timeout`, so a running process has a single breaker config `(3, 30.0)` and the dilution is inert outside tests. Labeling by config key was deliberately deferred: it would change the metric's series contract and break existing unlabeled dashboards for a scenario that doesn't occur in normal deployments.
- Fixed the now-stale `_CircuitBreaker` docstring that still described the removed first-wins behavior.

## Gate
`make check`: **779 passed, 4 deselected, coverage 94.33% (≥92 required), ruff + mypy --strict clean.**

## Self-review (a–d)
- **(a) Cleverness / drafting leftovers?** None. The `built = {src._cfg.cb_failure_threshold: src for ...}` dict-comp normalizes access after building in variable order — load-bearing for the both-orders intent, not decoration. `except _CACHE_LOCK_ERRORS` over an empty tuple when duckdb is absent is valid and intentional (declines to swallow `ImportError`).
- **(b) Claims verifiable?** The `make check` line is the exact command output (count + coverage % read from the run, not asserted from memory). The `duckdb.IOException` claim was reproduced with a real subprocess lock.
- **(c) Matches existing patterns?** The guarded `try: import duckdb / except ImportError` mirrors `cache.py`'s existing pattern. New `get_app` tests sit in `TestGetApp` alongside the existing env-var tests; the breaker test sits in `TestCircuitBreakerWiring` next to `test_shared_breaker_across_instances` and reuses the conftest `_reset_shared_source_state` autouse fixture.
- **(d) Data-system design gates.** Touches **gate 1 (overloaded field):** the single unlabeled gauge conflates multiple breakers. Real-world impact is near-zero (one config per process); labeling deferred; the dilution is **documented** per #191's sanctioned option — so this is *not* an unfiled symptom-patch. #191 is the filed root-cause record, resolved by documentation.

## Known non-blocking tradeoffs (from the adversarial pass)
1. `api.cache_disabled_lock_conflict` is logged for any `duckdb.IOException` at open time (a corrupt/disk-full `cache.db` would also degrade to cache-less under this label). Kept the issue-mandated key (docs reference it, and the multi-worker case is the expected cause); `error=str(exc)` is attached for disambiguation. Narrowing by matching the lock-error *string* was rejected as drift-coupling.
2. A base install without the `[cache]` extra and `DOMAIN_SCOUT_CACHE` unset still crash-loops in `get_app` (the `ImportError` is correctly *not* swallowed). Pre-existing and outside #169's lock-conflict scope — flagged as a follow-up, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4
