### PR TITLE
Degrade get_app to cache-less when [cache] extra is missing (#193)

### DIFF
--- a/domain_scout/api.py
+++ b/domain_scout/api.py
@@ -286,6 +286,11 @@ def get_app() -> FastAPI:
       the warning.
     * **Bad env values.** A non-numeric ``DOMAIN_SCOUT_MAX_CONCURRENT`` logs a
       warning and falls back to the default (3) instead of crashing at startup.
+    * **Missing [cache] extra.** A base install lacks ``duckdb``, yet
+      ``DOMAIN_SCOUT_CACHE`` still defaults to enabled. Rather than crash-loop
+      with ``ImportError`` at startup, the factory logs
+      ``api.cache_disabled_missing_extra`` and starts cache-less. Install
+      ``domain-scout-ct[cache]`` to enable caching (#193).
     """
     raw_max_concurrent = os.environ.get("DOMAIN_SCOUT_MAX_CONCURRENT", "3")
     try:
@@ -303,6 +308,15 @@ def get_app() -> FastAPI:
     if cache_enabled:
         try:
             cache = DuckDBCache(cache_dir=cache_dir)
+        except ImportError as exc:
+            # Base install without the [cache] extra: DuckDBCache.__init__ raises
+            # ImportError (duckdb absent) from a single guard. With the cache
+            # extra uninstalled DOMAIN_SCOUT_CACHE still defaults to "true", so
+            # `serve` (workers=1) and `uvicorn ...:get_app` would crash-loop.
+            # Degrade to cache-less rather than crash; the message names the
+            # extra to install (#193).
+            log.warning("api.cache_disabled_missing_extra", error=str(exc))
+            cache = None
         except _CACHE_LOCK_ERRORS as exc:
             # Another writer already holds cache.db (single-writer constraint).
             # Degrade to cache-less rather than corrupt the file or crash-loop.

--- a/domain_scout/tests/test_api.py
+++ b/domain_scout/tests/test_api.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -283,6 +284,26 @@ class TestGetApp:
             app = get_app()
         assert app.state.cache is None
         assert TestClient(app).get("/health").status_code == 200
+
+    def test_get_app_missing_cache_extra_falls_back_to_cacheless(self) -> None:
+        """A base install without the [cache] extra (duckdb absent) with
+        DOMAIN_SCOUT_CACHE unset degrades to cache=None instead of crash-looping
+        with ImportError at startup — the path 'serve' and 'uvicorn ...:get_app'
+        take by default (#193)."""
+        # Simulate the base install: duckdb is None, so DuckDBCache.__init__
+        # raises its real ImportError from the single `duckdb is None` guard.
+        env = dict(os.environ)
+        env.pop("DOMAIN_SCOUT_CACHE", None)  # unset -> cache defaults to enabled
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("domain_scout.cache.duckdb", None),
+            capture_logs() as logs,
+        ):
+            app = get_app()
+        assert app.state.cache is None
+        assert TestClient(app).get("/health").status_code == 200
+        events = [e["event"] for e in logs]
+        assert events.count("api.cache_disabled_missing_extra") == 1
 
 
 class TestScanRequest:


### PR DESCRIPTION
Fixes #193.

## Problem

In a base install **without the `[cache]` extra**, `duckdb` is absent and `DuckDBCache.__init__` raises `ImportError` from its `if duckdb is None:` guard. `get_app()` defaults `DOMAIN_SCOUT_CACHE` to `"true"` (enabled), so it calls `DuckDBCache(...)` and the `ImportError` propagates → **crash-loop at startup**. The `except _CACHE_LOCK_ERRORS` clause added by #169 resolves to `()` in a base install (duckdb absent at import time), so it catches nothing.

`domain-scout serve` (workers=1) hits this by default: it dispatches to `uvicorn.run("domain_scout.api:get_app", factory=True)` (cli.py:229-234) and only forces `DOMAIN_SCOUT_CACHE=false` when `workers > 1`.

## Fix

Extend the #169 *degrade-loudly-to-cacheless* idiom: a new `except ImportError` clause in `get_app` logs `api.cache_disabled_missing_extra` (the message names the extra to install) and starts cache-less instead of crashing. Also documented as a third foot-gun in the `get_app` docstring, plus a regression test.

## Repro evidence (real base-install venv, `duckdb` NOT installed)

**Pre-fix** — `DOMAIN_SCOUT_CACHE` unset, `get_app()`:
```
File ".../domain_scout/api.py", line 305, in get_app
    cache = DuckDBCache(cache_dir=cache_dir)
File ".../domain_scout/cache.py", line 56, in __init__
    raise ImportError(
ImportError: duckdb is required for caching. Install it with: pip install domain-scout-ct[cache]
_CACHE_LOCK_ERRORS = ()
EXIT=1
```

**Post-fix** — same env, same call:
```
warning  api.cache_disabled_missing_extra  error='duckdb is required for caching. Install it with: pip install domain-scout-ct[cache]'
_CACHE_LOCK_ERRORS = ()
OK startup succeeded; cache = None
GET /health -> 200
EXIT=0
```

## Verification (commands + exit codes)

- `uv run pytest domain_scout/tests -m "not integration" -q` (the exact CI invocation, ci.yml:92) → **780 passed, 4 deselected**, coverage 94.35% >= 92%, exit `0`.
- `uv run ruff check .` → `All checks passed!`, exit `0`.
- `uv run ruff format --check .` → `51 files already formatted`, exit `0`.
- New test `test_get_app_missing_cache_extra_falls_back_to_cacheless` + existing `test_get_app_cache_lock_conflict_falls_back_to_cacheless` pass together (9/9 in `TestGetApp`).

Note: `test_integration.py::test_full_scout_run` fails locally — it is `@pytest.mark.integration` (hits live crt.sh), deselected in CI, and untouched by this change.

## Pre-PR self-review (mandatory gate)

Ran one synchronous adversarial pass on the final diff (general-purpose subagent). Verdict: ACCEPT, no blockers/majors, three nits all dispositioned as accept.

1. **Leftover cleverness?** None. Diff is 35 insertions, 0 deletions: one `except` clause, one docstring bullet, one test, one import. No dead code or drafting artifacts.
2. **Claims verifiable exactly as stated?** Yes — the repro output, the CI pytest command + count, and both lint commands above were run and their exit codes observed. The two `except` clauses are provably disjoint: `issubclass(duckdb.IOException, ImportError)` is `False` (IOException MRO: IOException → OperationalError → DatabaseError → Error → Exception), so the new clause cannot shadow the #169 lock-conflict clause; ordering is safe.
3. **Matches existing patterns?** Yes — parallels `cli.py::_get_cache_or_exit` (lines 260-268), which already wraps `DuckDBCache(...)` in `except ImportError` and names `pip install domain-scout-ct[cache]`. This fix uses the same idiom but **fail-opens** (`cache=None`) rather than `raise typer.Exit`, which is correct for a long-running server factory vs. a one-shot CLI command. Sits directly beside the #169 clause it mirrors.
4. **(d) Data-System Design Gates / patch-vs-fix.** Touches none of the five data-model gates — this is a startup-robustness fix, not classification/matching/scoring/linking/aggregation; no money/data totals involved. It is a **root-cause fix** for the crash class named in #193 (unhandled missing-optional-dep at factory startup), not a symptom-patch: the base-install path now degrades loudly and deterministically, matching the CLI's existing handling.

Nits raised and accepted (no change needed): (a) bare `except ImportError` could in principle mask a future lazy import added inside `DuckDBCache.__init__` — identical residual to the already-accepted `cli.py` idiom, guarded by a code comment; (b) the regression test leaves `_CACHE_LOCK_ERRORS` as `(IOException,)` rather than `()` — a fidelity gap that does not change the outcome, since ImportError is caught by the first clause.

## Downstream

domain-scout is a path-dependency of insurance-market-db and pinned by domain-scout-api (`.github/domain-scout.ref`). This PR does not touch those consumers; lock/pin sync is handled after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
