### PR TITLE
Size RDAP semaphore from process-wide constant, not first instance (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handle the new exception. New metric label: `ct_queries_total{status="skipped_org"}`.
   (#163)
 
+### Fixed
+
+- **First-instance-wins breakers** — CT/RDAP circuit breakers moved to
+  class-level registries keyed by `(failure_threshold, recovery_timeout)`, so
+  effective thresholds no longer depend on instance construction order; an
+  autouse conftest fixture resets the shared state between tests (#172, #190)
+- **RDAP semaphore sizing** — the shared per-loop semaphore is now sized from
+  the process-wide `RDAP_MAX_CONCURRENT` constant instead of the first
+  instance's config; `ScoutConfig.max_rdap_concurrent` is deprecated (kept for
+  compatibility, non-default values log a warning) (#172)
+
 ## [0.11.0] - 2026-04-01
 
 ### Added

--- a/domain_scout/config.py
+++ b/domain_scout/config.py
@@ -88,6 +88,10 @@ class ScoutConfig:
     cb_recovery_timeout: float = 30.0
 
     # --- RDAP rate limiting ---
+    # DEPRECATED (#172): rdap.org is a shared external resource, so the
+    # concurrency cap is process-wide (RDAP_MAX_CONCURRENT in sources/rdap.py),
+    # not per-scan. This field no longer sizes the shared semaphore; it is kept
+    # for constructor compatibility and a non-default value logs a warning.
     max_rdap_concurrent: int = 3
     rdap_cb_failure_threshold: int = 3
     rdap_cb_recovery_timeout: float = 30.0

--- a/domain_scout/sources/rdap.py
+++ b/domain_scout/sources/rdap.py
@@ -18,6 +18,17 @@ log = structlog.get_logger()
 
 _RDAP_BOOTSTRAP = "https://rdap.org/domain/"
 
+# Process-wide cap on concurrent rdap.org requests. rdap.org is a single shared
+# external resource, so its concurrency limit is a property of the *process*, not
+# of any individual scan. A per-``ScoutConfig`` value cannot size a single shared
+# semaphore deterministically: on a long-lived shared loop (the API's uvicorn
+# loop) the first instance to touch it froze the cap for every later scan (#172),
+# and giving each config its own semaphore would sum caps against rdap.org
+# (N1 + N2). The shared semaphore is therefore always sized to this constant.
+# ``ScoutConfig.max_rdap_concurrent`` is retained for backward compatibility but
+# no longer sizes the shared semaphore (see its deprecation note).
+RDAP_MAX_CONCURRENT = 3
+
 # TLDs not in the IANA RDAP bootstrap registry (https://data.iana.org/rdap/dns.json).
 # Requests to rdap.org for these TLDs return 404.  Skip them to avoid
 # unnecessary HTTP round-trips and noisy warning logs.
@@ -139,12 +150,16 @@ class RDAPLookup:
       the same config share one breaker; differing thresholds get their own
       (each still trips independently on rdap.org failures).
     - The semaphore is a single per-event-loop rate limiter — one global cap on
-      concurrent rdap.org requests, never the sum of per-scan caps. It is sized
-      from the config of whichever instance first uses it on a given loop and is
-      recreated when the loop changes (``Scout.discover`` runs ``asyncio.run``
-      per call, so the CLI gets a fresh, correctly-sized semaphore per scan;
-      concurrent scans on the API's shared loop share one cap). Profiles do not
-      vary ``max_rdap_concurrent``, so this is deterministic in practice.
+      concurrent rdap.org requests, never the sum of per-scan caps. Its size is
+      the process-wide ``RDAP_MAX_CONCURRENT`` constant, not a per-config value,
+      so the effective cap no longer depends on which instance touches the loop
+      first (#172). It is still recreated when the loop changes because a
+      Semaphore is bound to the loop it was created in (``Scout.discover`` runs
+      ``asyncio.run`` per call, so the CLI gets a fresh semaphore per scan;
+      concurrent scans on the API's shared loop share the one cap).
+
+    ``ScoutConfig.max_rdap_concurrent`` is deprecated (#172) and no longer sizes
+    this semaphore; constructing with a non-default value logs a warning.
     """
 
     # Shared breakers keyed by (failure_threshold, recovery_timeout).
@@ -155,6 +170,14 @@ class RDAPLookup:
 
     def __init__(self, config: ScoutConfig) -> None:
         self._cfg = config
+        if config.max_rdap_concurrent != RDAP_MAX_CONCURRENT:
+            # Honest deprecation: the shared semaphore is process-wide, so a
+            # per-config override is ignored rather than silently obeyed (#172).
+            log.warning(
+                "rdap.max_rdap_concurrent_deprecated",
+                configured=config.max_rdap_concurrent,
+                effective=RDAP_MAX_CONCURRENT,
+            )
         self._breaker = self._get_breaker(
             config.rdap_cb_failure_threshold,
             config.rdap_cb_recovery_timeout,
@@ -210,17 +233,21 @@ class RDAPLookup:
         }
 
     def _ensure_semaphore(self) -> asyncio.Semaphore:
-        """Return the shared per-loop rdap.org semaphore, sized from this config.
+        """Return the shared per-loop rdap.org semaphore, sized to RDAP_MAX_CONCURRENT.
+
+        The size is the process-wide ``RDAP_MAX_CONCURRENT`` constant, so the
+        effective cap is deterministic and independent of which instance touches
+        the loop first (#172) — unlike the prior behaviour, which froze the cap
+        from the first instance's ``max_rdap_concurrent`` on a shared loop.
 
         When Scout.discover() calls asyncio.run() per invocation, each call
         creates a new event loop. A Semaphore from a previous loop raises
         "bound to a different event loop", so it is recreated when the loop
-        changes — sized from the current instance's ``max_rdap_concurrent``
-        rather than a value frozen from the first-ever instance (#172).
+        changes.
         """
         loop_id = id(asyncio.get_running_loop())
         if RDAPLookup._semaphore is None or RDAPLookup._semaphore_loop_id != loop_id:
-            RDAPLookup._semaphore = asyncio.Semaphore(self._cfg.max_rdap_concurrent)
+            RDAPLookup._semaphore = asyncio.Semaphore(RDAP_MAX_CONCURRENT)
             RDAPLookup._semaphore_loop_id = loop_id
         return RDAPLookup._semaphore
 

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -11,6 +11,7 @@ import pytest
 
 from domain_scout.config import ScoutConfig
 from domain_scout.sources.rdap import (
+    RDAP_MAX_CONCURRENT,
     RDAP_SKIP_TLDS,
     RDAPLookup,
     _RDAPCircuitBreaker,
@@ -458,8 +459,9 @@ class TestRDAPRateLimiting:
         """Semaphore is created lazily in _ensure_semaphore, not __init__."""
         config = ScoutConfig(max_rdap_concurrent=2)
         rdap = RDAPLookup(config)
-        # Semaphore should NOT be created in __init__ — it must be created
-        # in the correct event loop by _ensure_semaphore, sized from this config.
+        # Semaphore should NOT be created in __init__ — it must be created in the
+        # correct event loop by _ensure_semaphore (sized to the process-wide
+        # RDAP_MAX_CONCURRENT, #172). The config field is retained for compat.
         assert RDAPLookup._semaphore is None
         assert rdap._cfg.max_rdap_concurrent == 2
 
@@ -474,6 +476,52 @@ class TestRDAPRateLimiting:
         # Semaphore should now exist and be bound to current loop
         assert RDAPLookup._semaphore is not None
         assert RDAPLookup._semaphore_loop_id == id(asyncio.get_running_loop())
+
+    @pytest.mark.asyncio
+    async def test_semaphore_size_order_independent_on_shared_loop(self) -> None:
+        """Regression (#172): the shared rdap.org cap is process-wide, not frozen
+        from whichever config touches the loop first.
+
+        Before the fix, on a long-lived shared loop (the API's uvicorn loop) the
+        semaphore was sized from the first instance's ``max_rdap_concurrent``: a
+        strict scan (cap 1) constructed first would throttle a concurrent broad
+        scan to 1, or a broad scan (cap 99) would let a strict scan run 99-wide —
+        order-dependent and unreproducible. Now both instances share one
+        semaphore sized to ``RDAP_MAX_CONCURRENT`` regardless of order.
+        """
+        mock_client = _make_httpx_mock(json_payload={"entities": []})
+
+        async def _capacity(sem: asyncio.Semaphore) -> int:
+            # Count permits without touching private attrs: acquire returns
+            # immediately while permits remain, so drain then restore.
+            acquired = 0
+            while not sem.locked():
+                await sem.acquire()
+                acquired += 1
+            for _ in range(acquired):
+                sem.release()
+            return acquired
+
+        async def _shared_cap(first: RDAPLookup, second: RDAPLookup) -> int:
+            # Fresh shared state; both instances then query on this one loop.
+            RDAPLookup._semaphore = None
+            RDAPLookup._semaphore_loop_id = None
+            with patch("domain_scout.sources.rdap.httpx.AsyncClient", return_value=mock_client):
+                await first.get_registrant_org("first.com")
+                await second.get_registrant_org("second.com")
+            # Both resolved to the one shared per-loop semaphore.
+            assert first._ensure_semaphore() is second._ensure_semaphore()
+            return await _capacity(first._ensure_semaphore())
+
+        strict = RDAPLookup(ScoutConfig(max_rdap_concurrent=1))
+        broad = RDAPLookup(ScoutConfig(max_rdap_concurrent=99))
+
+        cap_strict_first = await _shared_cap(strict, broad)
+        cap_broad_first = await _shared_cap(broad, strict)
+
+        # Deterministic and order-independent: neither config's value wins.
+        assert cap_strict_first == RDAP_MAX_CONCURRENT
+        assert cap_broad_first == RDAP_MAX_CONCURRENT
 
 
 class TestExtractRegistrar:

--- a/domain_scout/tests/test_rdap.py
+++ b/domain_scout/tests/test_rdap.py
@@ -523,6 +523,17 @@ class TestRDAPRateLimiting:
         assert cap_strict_first == RDAP_MAX_CONCURRENT
         assert cap_broad_first == RDAP_MAX_CONCURRENT
 
+    def test_constant_matches_config_default(self) -> None:
+        """Tripwire (#172): RDAP_MAX_CONCURRENT must equal the ScoutConfig default.
+
+        config.py cannot import the constant from sources/rdap.py (circular
+        import), so the two ``3``s are coupled only by comment. Their equality
+        is what guarantees a default-constructed config never logs the
+        ``rdap.max_rdap_concurrent_deprecated`` warning — this test turns that
+        comment coupling into a CI failure if either side drifts.
+        """
+        assert ScoutConfig().max_rdap_concurrent == RDAP_MAX_CONCURRENT
+
 
 class TestExtractRegistrar:
     """Tests for extract_registrar()."""


### PR DESCRIPTION
Closes #172.

## The remaining first-instance-wins state

PR #190 (wave 5) made the CT/RDAP circuit breakers config-keyed registries — deterministic and order-independent. It left **one** piece of first-instance-wins state that #172 is still about: the **RDAP semaphore size**.

`_ensure_semaphore` sized the single shared per-loop semaphore from `self._cfg.max_rdap_concurrent` — i.e. from whichever `RDAPLookup` instance first touched the loop. On the CLI this is benign (`Scout.discover` runs `asyncio.run` per scan → a fresh loop → a fresh semaphore). On the API's long-lived shared uvicorn loop it is the exact bug #172 describes: a `strict` scan (`max_rdap_concurrent=1`) constructed first would throttle a concurrent `broad` scan to 1, or a `broad` scan (say 99) would let a strict scan run 99-wide — order-dependent and unreproducible.

## Fix: process-wide constant, not per-config

The shared semaphore is now sized from a module constant `RDAP_MAX_CONCURRENT = 3` (matching the prior default), so the effective cap is deterministic regardless of construction order. `ScoutConfig.max_rdap_concurrent` is **deprecated** — kept for constructor compatibility, but it no longer sizes the shared semaphore and a non-default value logs `rdap.max_rdap_concurrent_deprecated`. Per-loop recreation (via `id(loop)`) is unchanged.

### Why the #190 registry parallel *cannot* apply here

#190 resolved the breakers with a class-level registry keyed by config params — different configs get **separate** breakers. That works because each breaker is independent. The semaphore is different: it must stay a **single** object protecting rdap.org.

- Keying the semaphore per-config (a registry of semaphores) would let two profiles **sum** their caps against rdap.org (N1 + N2) — the exact thing #190 explicitly rejected.
- `min`-aggregating caps across configs into one semaphore would let one strict scan (cap 1) **permanently ratchet** the whole process down for the life of the loop.

rdap.org is a single shared external resource, so its concurrency cap is a property of the **process**, not any scan. A process-wide constant is the honest model (issue option **(a)**); it deviates from the literal "extend the registry" instruction for the reason above, which is stated in the code comment at the constant.

## Verification (commands run, exit codes confirmed)

- `uv run pytest -m "not integration" -q` (the CI invocation) → **781 passed, 4 deselected**, coverage **94.37%** (gate 92). exit 0.
- `uv run mypy domain_scout/` → `Success: no issues found in 51 source files`. exit 0.
- `uv run ruff check domain_scout/` → `All checks passed!` exit 0.
- `uv run ruff format --check domain_scout/` → `51 files already formatted`. exit 0.
- **Two-instances-different-config regression test** — `test_semaphore_size_order_independent_on_shared_loop`: builds a `strict` (`max_rdap_concurrent=1`) and a `broad` (`=99`) `RDAPLookup`, runs both `get_registrant_org` awaits on **one** running loop, and asserts the shared semaphore capacity == `RDAP_MAX_CONCURRENT` in **both** construction orders (drain-then-restore probe, no private attrs). Manually confirmed it **fails** against the old sizing — reverting `_ensure_semaphore` to `self._cfg.max_rdap_concurrent` produces `assert 1 == 3` (strict-first froze the cap to 1).
- The 2 suite warnings are the pre-existing `AsyncMock never awaited` in `test_subsidiary.py` (documented in #190), untouched here.

## Self-review

**(1) Anything clever or leftover?** No. The test's `_capacity` probe drains the semaphore with non-blocking `acquire()` (only while `not locked()`) then restores every permit — mypy-safe (avoids `Semaphore._value`) and deadlock-free. The manual `_semaphore = None` reset inside the test is load-bearing (both orderings share the one test loop, so the second must force a recreate). No dead branches or debug leftovers.

**(2) Claims verifiable?** The counts/exit codes above are from the exact commands on this branch. The regression assertion's fail-against-old was reproduced firsthand.

**(3) #190 registry parallel?** Named above: breakers use a per-config registry because they're independent; the semaphore must stay single, so the same "make shared class state deterministic" goal is met with a process-wide constant instead of a per-key registry — and the section explains why a registry/min would be wrong here.

**(d) Design Gates / patch-vs-fix.** Root-cause fix, not a symptom patch: the defect was config-derived shared state (first-wins). Touches **Gate 1 (overloaded field)** — the fix does *not* create a silent lying field: `max_rdap_concurrent` is documented as deprecated in `config.py` and the `RDAPLookup` docstring, and emits a runtime warning when overridden, so an operator who sets it learns it's ignored. No money/data totals involved. No filed-issue debt left open.

## Residual notes for consumers (deploy: pull only)

- **Behavior change to surface:** post-#190 a CLI scan with an explicit `max_rdap_concurrent` up-tune (e.g. 10) got a size-10 semaphore; it is now always 3. Default (3) is unchanged, so anyone on the default sees **no** change — no profile (`broad`/`balanced`/`strict`) varies this field. Only explicit up-tuners lose the effect, and they get the deprecation warning. domain-scout is path-dep'd by insurance-market-db and SHA-pinned by domain-scout-api; the constructor signature is unchanged and `ScoutConfig(max_rdap_concurrent=…)` still constructs, so no consumer breaks.
- `RDAP_MAX_CONCURRENT` duplicates the field default `3` (coupled by comment, not import): `config.py` cannot import from `sources/rdap.py` (rdap.py imports `ScoutConfig` from config.py → circular). The "default never warns" property depends on the two staying equal.

## #173 (Dockerfile double `uv sync`) — already fixed, no PR

Checked the live `Dockerfile`: step 1 is `uv sync … --no-install-project` (cached deps layer) and step 2 is already `uv pip install --python /app/.venv --no-deps .` — the single-project-install #173 asks for. Like the breakers, #190 landed this and the issue was just left open. No change needed; #173 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDHSHd2j5ZKqF5QpzEhP4
