### PR TITLE
Generate eval baseline substrate + fail loudly when it's missing (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spurious "confidence changed" entries); it emits a single run-level
   `scorer_changed` warning instead, while non-confidence changes (`resolves`,
   `sources`, `rdap_org`) are still reported per domain.
+- Eval substrate generator (`python -m domain_scout.eval --mode record`, wired as
+  `make eval-baselines`): runs live discovery for the ground-truth entities and
+  (re)writes the git-ignored `baselines/` substrate plus a provenance
+  `baselines/manifest.json` referencing exactly the files that run produced
+  (#188). Each manifest entry carries a `sha256`; the header stamps
+  `generated_at`, `tool_version`, `scorer` identity, and `git_commit`, so the
+  point-in-time snapshot's decay is detectable rather than silent. `--limit N`
+  records a smoke-scale subset. Re-running is safe and overwrites the manifest to
+  reference only the current run's outputs.
 
 ### Changed
+- `make eval` now fails loudly (`EvalSubstrateError`, non-zero exit) instead of
+  printing a warning and rendering an empty — and misleadingly "passing" —
+  report when the baseline substrate is missing (#188). The `manifest.json` is
+  now required and authoritative: no manifest, an unparseable manifest, or a
+  referenced file that is absent or whose sha256 no longer matches is a hard
+  error, and only manifest-listed files are evaluated. Loose `{label_id}.json`
+  files without a manifest are not trusted (an interrupted `record` run can leave
+  a partial set), so `record` writes the manifest atomically and last. `make
+  eval` therefore requires a prior `make eval-baselines`. A substrate recorded
+  under a different scorer than the current one emits a stderr warning. (The
+  learned leg's post-pipeline re-scoring approximation, #187, is unchanged and
+  orthogonal.)
 - The `ct_org_match` source now requires a strict word-bounded org-name match in
   addition to the fuzzy `org_match_threshold`. The fuzzy scorer credited
   raw-substring hits (`Aon` in `kaonavi`, `Generali` in `Generalist`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ make test-integration  # hits real external services (crt.sh, RDAP, DNS)
 make lint          # ruff check + mypy --strict
 make format        # ruff fix + ruff format
 make check         # format + lint + test
-make eval          # run evaluation harness against baselines
+make eval          # run evaluation harness against the baseline substrate
+make eval-baselines  # (re)generate the git-ignored baseline substrate + manifest
 ```
 
 ## Tech Stack
@@ -96,6 +97,14 @@ domain_scout/
 
 - **Fingerprint mode** (`--mode fingerprint`): for DV-cert companies where CT org search is blind. Skips Strategy A, adds DNS fingerprint verification as post-processing step (between RDAP corroboration and scoring). Extracts MX tenant IDs (Proofpoint, M365, Barracuda, IronPort, FireEye), NS zones, IP /24 prefixes, and SPF includes from seeds and candidates. MX tenant match treated as equivalent to `rdap_registrant_match` in corroboration scoring. Implies `--deep` mode.
 - Shodan reverse DNS candidate generation is deferred (see #110) — fingerprint mode works entirely with standard DNS queries (free, unlimited)
+
+## Eval substrate (`baselines/`)
+
+- `make eval` scores recorded `ScoutResult` snapshots (`baselines/{label_id}.json`) against `eval_ground_truth.yaml`. The whole `baselines/` dir — snapshots **and** `manifest.json` — is git-ignored: it's a locally-generated, point-in-time artifact, never committed (which is why a fresh checkout has none; issue #188).
+- **Regenerate with `make eval-baselines`** (`= python -m domain_scout.eval --mode record`). It runs live discovery (default `ScoutConfig`, `use_learned_scorer=False`), writes one JSON per entity, and writes `baselines/manifest.json` referencing exactly the files that run produced. `make eval-baselines LIMIT=3` records a smoke-scale subset. Re-running is safe; it overwrites the manifest to reference only the current run's outputs.
+- **The manifest is the substrate's source of truth.** Each entry carries `sha256` + `domains`; the manifest header stamps `generated_at`, `tool_version`, `scorer` (learned-scorer identity at record time), and `git_commit` — so decay is *detectable*, not silent (the gate-3 defect behind #188). It is **not** byte-identical across runs (CT is point-in-time); the *process* is what's reproducible.
+- **The manifest is mandatory.** `make eval` fails loudly (`EvalSubstrateError`, non-zero exit) when there is no manifest, when the manifest is unparseable, or when it references an absent or sha-mismatched file. Loose `{label_id}.json` files without a manifest are **not** trusted (an interrupted `record` run can leave a partial set) — the manifest is proof of a completed run, so `record` writes it atomically and last. So `make eval` requires a prior `make eval-baselines`; a missing/partial substrate must never read as a passing/neutral eval. It also warns (stderr) when the substrate's recorded scorer differs from the current one.
+- Full-sweep cost: 399 ground-truth entities × one live discovery each, serialized, bounded by `total_timeout=90s` and the crt.sh rate limits/circuit breaker. Budget a long single-threaded run; use `LIMIT` for quick refreshes. Known approximation in the learned leg: #187 (re-scores post-pipeline state) — orthogonal to substrate freshness.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint format check build clean docker-build docker-run eval
+.PHONY: install test lint format check build clean docker-build docker-run eval eval-baselines
 
 install:
 	uv sync --all-groups --all-extras
@@ -19,6 +19,12 @@ format:
 
 eval:
 	uv run python -m domain_scout.eval --mode baseline
+
+# (Re)generate the git-ignored baseline substrate + manifest via live discovery.
+# Point-in-time snapshot of CT data — see CLAUDE.md "Eval substrate". LIMIT scopes
+# a smoke run, e.g. `make eval-baselines LIMIT=3`; omit LIMIT for the full sweep.
+eval-baselines:
+	uv run python -m domain_scout.eval --mode record $(if $(LIMIT),--limit $(LIMIT))
 
 check: format lint test
 

--- a/domain_scout/eval.py
+++ b/domain_scout/eval.py
@@ -376,17 +376,30 @@ def _resolve_manifest_substrate(
     baselines_dir: Path,
     gt_by_id: dict[str, GroundTruthEntry],
 ) -> list[tuple[GroundTruthEntry, ScoutResult]]:
-    """Validate every manifest-referenced file, then load the ones in ground truth.
+    """Validate the manifest-referenced files in scope, then load them.
 
-    Fails loudly (``EvalSubstrateError``) if any referenced file is absent or its
-    on-disk digest no longer matches the manifest — a vanished or tampered
-    substrate must not read as a passing eval (issue #188, gate 3).
+    Validation (existence + sha256) covers exactly the manifest entries whose
+    ``label_id`` is in the requested ground truth. An unscoped run passes the
+    full ground truth, so the whole substrate is still checked; a ``--label``
+    debug run is not blocked by an unrelated entry's missing/corrupt file.
+
+    Fails loudly (``EvalSubstrateError``) if any in-scope referenced file is
+    absent or its on-disk digest no longer matches the manifest — a vanished or
+    tampered substrate must not read as a passing eval (issue #188, gate 3).
     """
+    relevant = [entry for entry in manifest.entries if entry.label_id in gt_by_id]
+    if not relevant:
+        raise EvalSubstrateError(
+            f"Baseline manifest at {baselines_dir / _MANIFEST_NAME} has no entries matching "
+            f"the ground truth ({len(manifest.entries)} manifest entries, "
+            f"{len(gt_by_id)} ground-truth label(s)). Nothing to evaluate."
+        )
+
     pairs: list[tuple[GroundTruthEntry, ScoutResult]] = []
     missing: list[str] = []
     corrupt: list[str] = []
 
-    for entry in manifest.entries:
+    for entry in relevant:
         fpath = baselines_dir / entry.file
         if not fpath.exists():
             missing.append(entry.file)
@@ -395,9 +408,7 @@ def _resolve_manifest_substrate(
         if actual != entry.sha256:
             corrupt.append(f"{entry.file} (manifest {entry.sha256[:12]}, on-disk {actual[:12]})")
             continue
-        gt = gt_by_id.get(entry.label_id)
-        if gt is not None:
-            pairs.append((gt, ScoutResult.model_validate_json(fpath.read_text())))
+        pairs.append((gt_by_id[entry.label_id], ScoutResult.model_validate_json(fpath.read_text())))
 
     if missing or corrupt:
         details: list[str] = []
@@ -411,12 +422,6 @@ def _resolve_manifest_substrate(
             f"Regenerate with `make eval-baselines`. — " + " | ".join(details)
         )
 
-    if not pairs:
-        raise EvalSubstrateError(
-            f"Baseline manifest at {baselines_dir / _MANIFEST_NAME} has no entries matching "
-            f"the ground truth ({len(manifest.entries)} manifest entries, "
-            f"{len(gt_by_id)} ground-truth label(s)). Nothing to evaluate."
-        )
     return pairs
 
 

--- a/domain_scout/eval.py
+++ b/domain_scout/eval.py
@@ -1,30 +1,52 @@
 """Evaluation harness for domain-scout: precision/recall against labeled ground truth.
 
-Supports two modes:
+Supports three modes:
   - baseline: load pre-recorded ScoutResult JSON files and compute metrics
   - live: run Scout.discover_async() against real services and compute metrics
+  - record: run live discovery and persist the results as the baseline substrate
+    (baselines/{label_id}.json) plus a provenance manifest (baselines/manifest.json)
 
 Usage:
   python -m domain_scout.eval --mode baseline
   python -m domain_scout.eval --mode live --output json
+  python -m domain_scout.eval --mode record --limit 3   # regenerate the substrate
+
+The ``baseline`` substrate (``baselines/`` + its manifest) is git-ignored and
+generated locally by ``--mode record`` (``make eval-baselines``). It is a
+point-in-time snapshot of live CT data: re-running the generator is safe and the
+manifest stamps provenance (generated_at, tool_version, scorer identity, git
+commit) so decay is *detectable*. It is not byte-identical across runs.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import math
+import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from domain_scout.models import ScoutResult
 
 _GROUND_TRUTH_PATH = Path(__file__).parent / "eval_ground_truth.yaml"
 _BASELINES_DIR = Path(__file__).parent.parent / "baselines"
+_MANIFEST_NAME = "manifest.json"
 
 _DEFAULT_K_VALUES = (5, 10, 20)
+
+
+class EvalSubstrateError(RuntimeError):
+    """The baseline substrate (``baselines/`` + manifest) is missing or corrupt.
+
+    Raised instead of silently producing an empty report so that a vanished or
+    tampered substrate fails the eval loudly rather than reading as a passing /
+    neutral run (issue #188, gate 3).
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +103,34 @@ class EvalReport(BaseModel):
     # Identity of the learned scorer that produced learned_entities,
     # e.g. "learned_lr/v1@2026-03-01+uncal" (None if the leg didn't run).
     learned_scorer: str | None = None
+
+
+class BaselineManifestEntry(BaseModel):
+    """One recorded baseline file, keyed to its ground-truth label."""
+
+    label_id: str
+    file: str  # filename relative to the baselines dir, e.g. "panw-20260217.json"
+    sha256: str  # digest of the file bytes at record time (corruption / drift check)
+    domains: int  # number of domains in the recorded ScoutResult
+
+
+class BaselineManifest(BaseModel):
+    """Provenance for a generated baseline substrate.
+
+    Written by ``--mode record`` and read by ``--mode baseline``. It lists
+    exactly the files the generator wrote this run, so the eval can fail loudly
+    when a referenced file goes absent or is tampered with, and so substrate
+    decay is detectable (``generated_at`` / ``scorer`` / ``git_commit``).
+    """
+
+    generator: str = "domain_scout.eval --mode record"
+    generated_at: str  # ISO-8601 UTC timestamp
+    tool_version: str
+    scorer: str  # learned-scorer identity at generation time (e.g. learned_lr/v1@...)
+    source: str  # provenance of the underlying data, e.g. "live crt.sh discovery"
+    mode: str = "live"
+    git_commit: str | None = None
+    entries: list[BaselineManifestEntry]
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +328,99 @@ def _learned_scorer_identity() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Substrate provenance (manifest) helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    """SHA-256 of a file's bytes."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git_commit() -> str | None:
+    """Best-effort short-circuiting lookup of the current git commit (or None)."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _load_manifest(baselines_dir: Path) -> BaselineManifest | None:
+    """Load the baseline manifest if present, else None.
+
+    A present-but-unparseable manifest (e.g. truncated by an interrupted write)
+    is a loud error, not a fall-through to "no manifest".
+    """
+    manifest_path = baselines_dir / _MANIFEST_NAME
+    if not manifest_path.exists():
+        return None
+    try:
+        return BaselineManifest.model_validate_json(manifest_path.read_text())
+    except ValidationError as exc:
+        raise EvalSubstrateError(
+            f"Baseline manifest at {manifest_path} is present but unparseable "
+            f"(truncated or malformed?). Regenerate with `make eval-baselines`. — {exc}"
+        ) from exc
+
+
+def _resolve_manifest_substrate(
+    manifest: BaselineManifest,
+    baselines_dir: Path,
+    gt_by_id: dict[str, GroundTruthEntry],
+) -> list[tuple[GroundTruthEntry, ScoutResult]]:
+    """Validate every manifest-referenced file, then load the ones in ground truth.
+
+    Fails loudly (``EvalSubstrateError``) if any referenced file is absent or its
+    on-disk digest no longer matches the manifest — a vanished or tampered
+    substrate must not read as a passing eval (issue #188, gate 3).
+    """
+    pairs: list[tuple[GroundTruthEntry, ScoutResult]] = []
+    missing: list[str] = []
+    corrupt: list[str] = []
+
+    for entry in manifest.entries:
+        fpath = baselines_dir / entry.file
+        if not fpath.exists():
+            missing.append(entry.file)
+            continue
+        actual = _sha256_file(fpath)
+        if actual != entry.sha256:
+            corrupt.append(f"{entry.file} (manifest {entry.sha256[:12]}, on-disk {actual[:12]})")
+            continue
+        gt = gt_by_id.get(entry.label_id)
+        if gt is not None:
+            pairs.append((gt, ScoutResult.model_validate_json(fpath.read_text())))
+
+    if missing or corrupt:
+        details: list[str] = []
+        if missing:
+            details.append(f"absent: {', '.join(missing)}")
+        if corrupt:
+            details.append(f"corrupt (sha256 mismatch): {'; '.join(corrupt)}")
+        raise EvalSubstrateError(
+            f"Baseline manifest at {baselines_dir / _MANIFEST_NAME} references "
+            f"{len(missing)} absent and {len(corrupt)} corrupt file(s). "
+            f"Regenerate with `make eval-baselines`. — " + " | ".join(details)
+        )
+
+    if not pairs:
+        raise EvalSubstrateError(
+            f"Baseline manifest at {baselines_dir / _MANIFEST_NAME} has no entries matching "
+            f"the ground truth ({len(manifest.entries)} manifest entries, "
+            f"{len(gt_by_id)} ground-truth label(s)). Nothing to evaluate."
+        )
+    return pairs
+
+
+# ---------------------------------------------------------------------------
 # Baseline evaluation
 # ---------------------------------------------------------------------------
 
@@ -287,24 +430,44 @@ def evaluate_baseline(
     baselines_dir: Path | None = None,
     k_values: tuple[int, ...] = _DEFAULT_K_VALUES,
 ) -> EvalReport:
-    """Evaluate pre-recorded baseline JSON files against ground truth.
+    """Evaluate the recorded baseline substrate against ground truth.
 
     Runs both scorer legs: the recorded (heuristic) ranking and a learned
     re-scoring of the same evidence.
+
+    The ``manifest.json`` written by ``--mode record`` is the substrate's single
+    source of truth and is *required*: every file it lists must exist and match
+    its recorded digest, and exactly those files (that also have a ground-truth
+    label) are evaluated. A missing manifest (e.g. a fresh checkout, or a
+    ``record`` run interrupted before the manifest was written), a
+    missing/corrupt referenced file, or an empty substrate raises
+    :class:`EvalSubstrateError` rather than yielding a silent, empty (and
+    misleadingly "passing") report — the #188 gate-3 defect.
     """
     bdir = baselines_dir or _BASELINES_DIR
+    manifest = _load_manifest(bdir)
+    if manifest is None:
+        raise EvalSubstrateError(
+            f"No baseline manifest ({_MANIFEST_NAME}) in {bdir}. The eval substrate is "
+            f"generated locally and git-ignored; run `make eval-baselines` to create it. "
+            f"(Loose {{label_id}}.json files without a manifest are not trusted — an "
+            f"interrupted `record` run can leave a partial set.)"
+        )
+
+    gt_by_id = {gt.label_id: gt for gt in ground_truth}
+    pairs = _resolve_manifest_substrate(manifest, bdir, gt_by_id)
+    current_scorer = _learned_scorer_identity()
+    if manifest.scorer != current_scorer:
+        print(
+            f"WARNING: baseline substrate was scored under {manifest.scorer} but the "
+            f"current scorer is {current_scorer}; learned-leg deltas may not reflect the "
+            f"shipping scorer. Regenerate with `make eval-baselines`.",
+            file=sys.stderr,
+        )
+
     results: list[EntityEvalResult] = []
     learned_results: list[EntityEvalResult] = []
-
-    for gt in ground_truth:
-        baseline_path = bdir / f"{gt.label_id}.json"
-        if not baseline_path.exists():
-            print(f"WARNING: baseline not found: {baseline_path}", file=sys.stderr)
-            continue
-
-        with open(baseline_path) as f:
-            scout_result = ScoutResult.model_validate_json(f.read())
-
+    for gt, scout_result in pairs:
         # Ranked domain list (already sorted by confidence desc in ScoutResult)
         ranked = [d.domain for d in scout_result.domains]
         results.append(_entity_result(gt, ranked, k_values))
@@ -316,6 +479,76 @@ def evaluate_baseline(
         learned_entities=learned_results,
         learned_scorer=_learned_scorer_identity() if learned_results else None,
     )
+
+
+# ---------------------------------------------------------------------------
+# Baseline substrate generation (record mode)
+# ---------------------------------------------------------------------------
+
+
+async def record_baselines(
+    ground_truth: list[GroundTruthEntry],
+    baselines_dir: Path | None = None,
+    *,
+    limit: int | None = None,
+    source: str = "live crt.sh discovery",
+) -> BaselineManifest:
+    """Run live discovery for each entity and persist the substrate + manifest.
+
+    Deterministic in *process* (re-runnable, same inputs -> same file layout),
+    not in *bytes*: the underlying CT data is point-in-time, so successive runs
+    can differ. The manifest stamps provenance so that drift is detectable.
+
+    ``limit`` records only the first N ground-truth entries (a smoke-scale
+    substrate); the manifest then references only the files this run wrote.
+    Uses the default :class:`ScoutConfig` (``use_learned_scorer=False``), so the
+    recorded ranking is the heuristic leg production emits by default.
+    """
+    from domain_scout import __version__
+    from domain_scout.models import EntityInput
+    from domain_scout.scout import Scout
+
+    bdir = baselines_dir or _BASELINES_DIR
+    bdir.mkdir(parents=True, exist_ok=True)
+    targets = ground_truth[:limit] if limit is not None else ground_truth
+
+    scout = Scout()
+    entries: list[BaselineManifestEntry] = []
+    for gt in targets:
+        entity = EntityInput(company_name=gt.company_name, seed_domain=gt.seeds)
+        scout_result = await scout.discover_async(entity)
+
+        fname = f"{gt.label_id}.json"
+        fpath = bdir / fname
+        fpath.write_text(scout_result.model_dump_json(indent=2))
+        entries.append(
+            BaselineManifestEntry(
+                label_id=gt.label_id,
+                file=fname,
+                sha256=_sha256_file(fpath),
+                domains=len(scout_result.domains),
+            )
+        )
+        print(f"recorded {gt.label_id}: {len(scout_result.domains)} domains", file=sys.stderr)
+
+    entries.sort(key=lambda e: e.label_id)
+    manifest = BaselineManifest(
+        generated_at=datetime.now(UTC).isoformat(),
+        tool_version=__version__,
+        scorer=_learned_scorer_identity(),
+        source=source,
+        mode="live",
+        git_commit=_git_commit(),
+        entries=entries,
+    )
+    # Write the manifest atomically (tmp + rename) and last: readers treat the
+    # manifest as proof of a completed run, so it must never appear truncated or
+    # ahead of the files it references (matches the repo's atomic-write pattern).
+    manifest_path = bdir / _MANIFEST_NAME
+    tmp_path = manifest_path.with_suffix(".json.tmp")
+    tmp_path.write_text(manifest.model_dump_json(indent=2) + "\n")
+    tmp_path.replace(manifest_path)
+    return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -422,9 +655,12 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--mode",
-        choices=["baseline", "live"],
+        choices=["baseline", "live", "record"],
         default="baseline",
-        help="Evaluation mode: baseline (pre-recorded JSON) or live (real queries)",
+        help=(
+            "baseline (pre-recorded JSON), live (real queries), or record "
+            "(run live discovery and (re)generate the baselines/ substrate + manifest)"
+        ),
     )
     parser.add_argument(
         "--output",
@@ -450,6 +686,12 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Evaluate only this label_id (default: all)",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="record mode: record only the first N ground-truth entries (smoke-scale substrate)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -461,10 +703,23 @@ def main(argv: list[str] | None = None) -> None:
             print(f"ERROR: label_id '{args.label}' not found in ground truth", file=sys.stderr)
             sys.exit(1)
 
-    if args.mode == "baseline":
-        report = evaluate_baseline(ground_truth, args.baselines_dir)
-    else:
-        report = asyncio.run(evaluate_live(ground_truth))
+    if args.mode == "record":
+        manifest = asyncio.run(record_baselines(ground_truth, args.baselines_dir, limit=args.limit))
+        bdir = args.baselines_dir or _BASELINES_DIR
+        print(
+            f"Wrote {len(manifest.entries)} baseline(s) + {_MANIFEST_NAME} to {bdir}",
+            file=sys.stderr,
+        )
+        return
+
+    try:
+        if args.mode == "baseline":
+            report = evaluate_baseline(ground_truth, args.baselines_dir)
+        else:
+            report = asyncio.run(evaluate_live(ground_truth))
+    except EvalSubstrateError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     if args.output == "json":
         print(report.model_dump_json(indent=2))

--- a/domain_scout/tests/test_eval.py
+++ b/domain_scout/tests/test_eval.py
@@ -385,6 +385,42 @@ class TestEvaluateBaseline:
         with pytest.raises(EvalSubstrateError, match="corrupt"):
             evaluate_baseline(gt, baselines_dir=tmp_path)
 
+    def test_label_scoped_run_ignores_out_of_scope_corruption(self, tmp_path: Path) -> None:
+        """--label debugging isn't blocked by an unrelated entry's absent/corrupt file.
+
+        Validation is scoped to the requested ground truth: a single-label run
+        over a substrate with unrelated damage succeeds, while the unscoped run
+        over the same substrate still fails loudly.
+        """
+
+        def _gt(label_id: str) -> GroundTruthEntry:
+            return GroundTruthEntry(
+                label_id=label_id,
+                company_name=label_id.title(),
+                seeds=[f"{label_id}.com"],
+                owned_domains=[f"{label_id}.com"],
+            )
+
+        _write_baseline_with_manifest(
+            tmp_path,
+            {
+                "alpha": _make_scout_result(["alpha.com"], company_name="Alpha"),
+                "beta": _make_scout_result(["beta.com"], company_name="Beta"),
+                "gamma": _make_scout_result(["gamma.com"], company_name="Gamma"),
+            },
+        )
+        # Damage the two entries that are NOT in scope: one absent, one tampered.
+        (tmp_path / "beta.json").unlink()
+        (tmp_path / "gamma.json").write_text('{"tampered": true}')
+
+        # Scoped run (mirrors main()'s --label filtering): succeeds on alpha alone.
+        report = evaluate_baseline([_gt("alpha")], baselines_dir=tmp_path, k_values=(1,))
+        assert [e.label_id for e in report.entities] == ["alpha"]
+
+        # Unscoped run over the same substrate: the damage is in scope -> loud.
+        with pytest.raises(EvalSubstrateError, match="1 absent and 1 corrupt"):
+            evaluate_baseline([_gt("alpha"), _gt("beta"), _gt("gamma")], baselines_dir=tmp_path)
+
     def test_manifest_no_matching_ground_truth_fails_loudly(self, tmp_path: Path) -> None:
         """A manifest with no entry matching the ground truth is a loud error."""
         gt = [

--- a/domain_scout/tests/test_eval.py
+++ b/domain_scout/tests/test_eval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import textwrap
 from datetime import UTC, datetime
 from pathlib import Path
@@ -10,8 +11,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from domain_scout.eval import (
+    BaselineManifest,
+    BaselineManifestEntry,
     EntityEvalResult,
     EvalReport,
+    EvalSubstrateError,
     GroundTruthEntry,
     MetricsAtK,
     collect_false_positives,
@@ -20,6 +24,7 @@ from domain_scout.eval import (
     evaluate_live,
     format_table,
     load_ground_truth,
+    record_baselines,
 )
 from domain_scout.models import (
     DiscoveredDomain,
@@ -247,8 +252,7 @@ class TestEvaluateBaseline:
             company_name="TestCo",
             seeds=["test.com"],
         )
-        baseline_path = tmp_path / "test-entity.json"
-        baseline_path.write_text(result.model_dump_json(indent=2))
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
 
         report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(3, 5))
         assert report.mode == "baseline"
@@ -273,8 +277,8 @@ class TestEvaluateBaseline:
 
         assert "evil.com" in entity.false_positive_domains
 
-    def test_missing_baseline_skipped(self, tmp_path: Path) -> None:
-        """Missing baseline file is skipped with warning."""
+    def test_empty_substrate_no_manifest_fails_loudly(self, tmp_path: Path) -> None:
+        """A directory with no manifest and no baseline files is a loud error (#188)."""
         gt = [
             GroundTruthEntry(
                 label_id="nonexistent",
@@ -283,35 +287,203 @@ class TestEvaluateBaseline:
                 owned_domains=["ghost.com"],
             )
         ]
-        report = evaluate_baseline(gt, baselines_dir=tmp_path)
-        assert len(report.entities) == 0
+        with pytest.raises(EvalSubstrateError, match="No baseline manifest"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_loose_files_without_manifest_fail_loudly(self, tmp_path: Path) -> None:
+        """Baseline files present but no manifest is a loud error (interrupted record).
+
+        The manifest is proof of a completed `record` run; without it a partial
+        set of {label_id}.json files must not read as a passing partial report.
+        """
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com"],
+            )
+        ]
+        # A loose baseline file, but no manifest.json alongside it.
+        (tmp_path / "test-entity.json").write_text(
+            _make_scout_result(["test.com"], company_name="TestCo").model_dump_json()
+        )
+        with pytest.raises(EvalSubstrateError, match="No baseline manifest"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_unparseable_manifest_fails_loudly(self, tmp_path: Path) -> None:
+        """A present-but-truncated manifest is a loud error, not a fall-through."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com"],
+            )
+        ]
+        (tmp_path / "manifest.json").write_text('{"entries": [')  # truncated JSON
+        with pytest.raises(EvalSubstrateError, match="unparseable"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_manifest_evaluates_only_listed_files(self, tmp_path: Path) -> None:
+        """With a manifest present, exactly the listed (and ground-truthed) files run."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com", "test.net"],
+            ),
+            GroundTruthEntry(
+                label_id="unrecorded",
+                company_name="Other",
+                seeds=["other.com"],
+                owned_domains=["other.com"],
+            ),
+        ]
+        result = _make_scout_result(["test.com", "test.net"], company_name="TestCo")
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
+
+        report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(2,))
+        # Only the manifest-listed label is evaluated; "unrecorded" is not in the
+        # substrate and is silently absent (not an error — it just wasn't recorded).
+        assert [e.label_id for e in report.entities] == ["test-entity"]
+
+    def test_manifest_missing_file_fails_loudly(self, tmp_path: Path) -> None:
+        """A manifest that references an absent file is a loud error (#188, gate 3)."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com"],
+            )
+        ]
+        result = _make_scout_result(["test.com"], company_name="TestCo")
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
+        # Delete the file the manifest still references.
+        (tmp_path / "test-entity.json").unlink()
+
+        with pytest.raises(EvalSubstrateError, match="absent"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_manifest_corrupt_file_fails_loudly(self, tmp_path: Path) -> None:
+        """A manifest whose file digest no longer matches is a loud error (#188, gate 3)."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com"],
+            )
+        ]
+        result = _make_scout_result(["test.com"], company_name="TestCo")
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
+        # Mutate the file so its sha256 diverges from the manifest.
+        (tmp_path / "test-entity.json").write_text('{"tampered": true}')
+
+        with pytest.raises(EvalSubstrateError, match="corrupt"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_manifest_no_matching_ground_truth_fails_loudly(self, tmp_path: Path) -> None:
+        """A manifest with no entry matching the ground truth is a loud error."""
+        gt = [
+            GroundTruthEntry(
+                label_id="other",
+                company_name="Other",
+                seeds=["other.com"],
+                owned_domains=["other.com"],
+            )
+        ]
+        result = _make_scout_result(["test.com"], company_name="TestCo")
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
+
+        with pytest.raises(EvalSubstrateError, match="no entries matching"):
+            evaluate_baseline(gt, baselines_dir=tmp_path)
+
+    def test_manifest_scorer_drift_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A substrate recorded under a different scorer emits a visible warning."""
+        gt = [
+            GroundTruthEntry(
+                label_id="test-entity",
+                company_name="TestCo",
+                seeds=["test.com"],
+                owned_domains=["test.com"],
+            )
+        ]
+        result = _make_scout_result(["test.com"], company_name="TestCo")
+        _write_baseline_with_manifest(
+            tmp_path, {"test-entity": result}, scorer="stale/v0@2000-01-01"
+        )
+
+        evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
+        assert "current scorer is" in capsys.readouterr().err
 
     @pytest.mark.integration
     def test_real_baselines(self) -> None:
-        """Evaluate against real baselines if they exist."""
-        if not _make_baselines_dir().exists():
-            pytest.skip("baselines/ directory not found")
+        """Evaluate against the real locally-generated substrate if it exists.
+
+        The concrete baselines/ substrate is git-ignored and regenerated by
+        ``make eval-baselines`` (issue #188), so this asserts the manifest
+        contract holds rather than hardcoding domains from a since-decayed
+        2026-02-24 snapshot.
+        """
+        bdir = _make_baselines_dir()
+        if not (bdir / "manifest.json").exists():
+            pytest.skip("baselines/manifest.json not found (run `make eval-baselines`)")
 
         gt = load_ground_truth()
         report = evaluate_baseline(gt)
-        assert len(report.entities) >= 3  # at least the original 3
-
-        # walmart-seed1: all 17 are TPs, no FPs
-        ws1 = next(e for e in report.entities if e.label_id == "walmart-seed1")
-        assert ws1.false_positive_domains == []
-
-        # walmart-seed2: hubspot.com and exacttarget.com are FPs
-        ws2 = next(e for e in report.entities if e.label_id == "walmart-seed2")
-        assert set(ws2.false_positive_domains) == {"hubspot.com", "exacttarget.com"}
-
-        # panw: all 26 are TPs
-        panw = next(e for e in report.entities if e.label_id == "panw-20260217")
-        assert panw.false_positive_domains == []
+        # Every evaluated entity corresponds to a ground-truth label.
+        gt_ids = {g.label_id for g in gt}
+        assert report.entities  # non-empty: a missing substrate would have raised
+        assert all(e.label_id in gt_ids for e in report.entities)
 
 
 def _make_baselines_dir() -> Path:
     """Return the real baselines directory path."""
     return Path(__file__).parent.parent.parent / "baselines"
+
+
+def _write_baseline_with_manifest(
+    baselines_dir: Path,
+    results: dict[str, ScoutResult],
+    scorer: str | None = None,
+) -> BaselineManifest:
+    """Write baseline JSON files plus a matching manifest into ``baselines_dir``.
+
+    Defaults the manifest scorer to the current identity so metric tests don't
+    emit spurious scorer-drift warnings; the drift test passes an explicit stale
+    value.
+    """
+    if scorer is None:
+        from domain_scout.eval import _learned_scorer_identity
+
+        scorer = _learned_scorer_identity()
+    entries: list[BaselineManifestEntry] = []
+    for label_id, result in results.items():
+        fname = f"{label_id}.json"
+        fpath = baselines_dir / fname
+        fpath.write_text(result.model_dump_json(indent=2))
+        entries.append(
+            BaselineManifestEntry(
+                label_id=label_id,
+                file=fname,
+                sha256=hashlib.sha256(fpath.read_bytes()).hexdigest(),
+                domains=len(result.domains),
+            )
+        )
+    manifest = BaselineManifest(
+        generated_at="2026-02-24T00:00:00+00:00",
+        tool_version="0.0.0-test",
+        scorer=scorer,
+        source="test fixture",
+        entries=entries,
+    )
+    (baselines_dir / "manifest.json").write_text(manifest.model_dump_json(indent=2))
+    return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +525,109 @@ class TestEvaluateLive:
         assert entity.metrics[0].precision == pytest.approx(0.667, abs=0.001)
         assert entity.metrics[0].false_positives == 1
         assert "evil.com" in entity.false_positive_domains
+
+
+# ---------------------------------------------------------------------------
+# record_baselines (substrate generation) tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecordBaselines:
+    @pytest.mark.asyncio
+    async def test_writes_files_and_manifest(self, tmp_path: Path) -> None:
+        """record_baselines persists one file per entity and a matching manifest."""
+        gt = [
+            GroundTruthEntry(
+                label_id="alpha",
+                company_name="Alpha",
+                seeds=["alpha.com"],
+                owned_domains=["alpha.com"],
+            ),
+            GroundTruthEntry(
+                label_id="beta",
+                company_name="Beta",
+                seeds=["beta.com"],
+                owned_domains=["beta.com"],
+            ),
+        ]
+        results = {
+            "Alpha": _make_scout_result(["alpha.com", "alpha.net"], company_name="Alpha"),
+            "Beta": _make_scout_result(["beta.com"], company_name="Beta"),
+        }
+
+        with patch("domain_scout.scout.Scout") as mock_scout_cls:
+            mock_scout = mock_scout_cls.return_value
+            mock_scout.discover_async = AsyncMock(
+                side_effect=lambda entity: results[entity.company_name]
+            )
+            manifest = await record_baselines(gt, baselines_dir=tmp_path)
+
+        # Files written per entity.
+        assert (tmp_path / "alpha.json").exists()
+        assert (tmp_path / "beta.json").exists()
+        # Manifest references exactly those files, sorted by label_id, with digests
+        # that match the bytes on disk.
+        assert [e.label_id for e in manifest.entries] == ["alpha", "beta"]
+        assert manifest.scorer  # scorer identity stamped
+        assert manifest.git_commit is None or isinstance(manifest.git_commit, str)
+        assert (
+            manifest.model_dump()
+            == BaselineManifest.model_validate_json(
+                (tmp_path / "manifest.json").read_text()
+            ).model_dump()
+        )
+
+        # The written substrate round-trips through evaluate_baseline (loud path).
+        report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
+        assert {e.label_id for e in report.entities} == {"alpha", "beta"}
+
+    @pytest.mark.asyncio
+    async def test_limit_records_smoke_subset(self, tmp_path: Path) -> None:
+        """--limit records only the first N entities; the manifest lists only those."""
+        gt = [
+            GroundTruthEntry(
+                label_id=f"e{i}",
+                company_name=f"Co{i}",
+                seeds=[f"co{i}.com"],
+                owned_domains=[f"co{i}.com"],
+            )
+            for i in range(5)
+        ]
+        with patch("domain_scout.scout.Scout") as mock_scout_cls:
+            mock_scout = mock_scout_cls.return_value
+            mock_scout.discover_async = AsyncMock(
+                side_effect=lambda entity: _make_scout_result(
+                    [f"{entity.company_name.lower()}.com"], company_name=entity.company_name
+                )
+            )
+            manifest = await record_baselines(gt, baselines_dir=tmp_path, limit=2)
+
+        assert [e.label_id for e in manifest.entries] == ["e0", "e1"]
+        assert not (tmp_path / "e2.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_rerun_manifest_references_only_current_run(self, tmp_path: Path) -> None:
+        """A narrower re-run overwrites the manifest to reference only its outputs."""
+        gt = [
+            GroundTruthEntry(
+                label_id=f"e{i}",
+                company_name=f"Co{i}",
+                seeds=[f"co{i}.com"],
+                owned_domains=[f"co{i}.com"],
+            )
+            for i in range(3)
+        ]
+        with patch("domain_scout.scout.Scout") as mock_scout_cls:
+            mock_scout = mock_scout_cls.return_value
+            mock_scout.discover_async = AsyncMock(
+                side_effect=lambda entity: _make_scout_result(
+                    [f"{entity.company_name.lower()}.com"], company_name=entity.company_name
+                )
+            )
+            await record_baselines(gt, baselines_dir=tmp_path)  # records e0,e1,e2
+            manifest = await record_baselines(gt, baselines_dir=tmp_path, limit=1)  # e0 only
+
+        assert [e.label_id for e in manifest.entries] == ["e0"]
 
 
 # ---------------------------------------------------------------------------
@@ -502,8 +777,7 @@ class TestLearnedScorerLeg:
                 not_owned=["filler.com"],
             )
         ]
-        baseline_path = tmp_path / "acme.json"
-        baseline_path.write_text(_make_learned_fixture().model_dump_json())
+        _write_baseline_with_manifest(tmp_path, {"acme": _make_learned_fixture()})
 
         report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
 
@@ -539,7 +813,7 @@ class TestLearnedScorerLeg:
             company_name="TestCo",
             seeds=["test.com"],
         )
-        (tmp_path / "test-entity.json").write_text(result.model_dump_json())
+        _write_baseline_with_manifest(tmp_path, {"test-entity": result})
 
         report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(3,))
         assert report.learned_entities[0].metrics == report.entities[0].metrics
@@ -548,16 +822,12 @@ class TestLearnedScorerLeg:
             == report.entities[0].false_positive_domains
         )
 
-    def test_no_baselines_no_learned_scorer_identity(self, tmp_path: Path) -> None:
-        gt = [
-            GroundTruthEntry(
-                label_id="missing",
-                company_name="Missing Corp",
-                seeds=["missing.com"],
-                owned_domains=["missing.com"],
-            )
-        ]
-        report = evaluate_baseline(gt, baselines_dir=tmp_path)
+    def test_no_learned_scorer_identity_on_empty_report(self) -> None:
+        """An empty EvalReport carries no learned-scorer identity."""
+        # Constructed directly: evaluate_baseline now raises on an empty substrate
+        # rather than returning an empty report (see
+        # TestEvaluateBaseline.test_empty_substrate_no_manifest_fails_loudly).
+        report = EvalReport(mode="baseline", entities=[])
         assert report.learned_entities == []
         assert report.learned_scorer is None
 
@@ -571,7 +841,7 @@ class TestLearnedScorerLeg:
                 not_owned=["filler.com"],
             )
         ]
-        (tmp_path / "acme.json").write_text(_make_learned_fixture().model_dump_json())
+        _write_baseline_with_manifest(tmp_path, {"acme": _make_learned_fixture()})
 
         report = evaluate_baseline(gt, baselines_dir=tmp_path, k_values=(1,))
         table = format_table(report)


### PR DESCRIPTION
## What & why

Closes #188. The production eval had **no substrate**: `baselines/` is git-ignored, so a fresh checkout has zero files. `make eval` then printed a warning per missing file and rendered an **empty — misleadingly "passing" — report** (issue #188, gate 3). Nothing regenerated the point-in-time snapshot and nothing detected its decay.

This ships (a) a documented, re-runnable substrate generator, (b) a smoke substrate proven end-to-end, and (c) a loud-failure gate so a missing/partial substrate can never read as passing.

## Changes

- **Generator** `--mode record` (`make eval-baselines`): runs live discovery for the ground-truth entities, writes `baselines/{label_id}.json` + a provenance `baselines/manifest.json` referencing exactly the files that run produced. Each entry carries a `sha256`; the manifest header stamps `generated_at`, `tool_version`, `scorer` identity, `git_commit`. `--limit N` records a smoke-scale subset. **The manifest is written atomically (tmp + rename) and last**, so its presence is proof of a completed run.
- **Loud failure** — the manifest is now the substrate's single, required source of truth. `evaluate_baseline` raises `EvalSubstrateError` (non-zero exit) on: no manifest, unparseable manifest, or an absent / sha-mismatched referenced file, or a manifest with no ground-truth-matching entries. Loose `{label_id}.json` files **without** a manifest are not trusted (an interrupted first `record` leaves a partial set that would otherwise read as a passing partial report). `make eval` now requires a prior `make eval-baselines`.
- Scorer-drift **warning** (stderr) when the substrate's recorded scorer differs from the current one.
- Docs: `CLAUDE.md` "Eval substrate" section (provenance, behavior change, full-run cost), `CHANGELOG` entries, `make eval-baselines` target.

## Self-review (per repo pre-PR discipline)

**1. Anything unnecessarily clever / leftover from drafting?** No. The change *removes* a code path (dual manifest/legacy resolution → single manifest contract) rather than adding cleverness. No dead code (legacy resolver deleted), no debug prints (the `print`s are intentional stderr provenance), `_git_commit`'s except is narrow (`OSError, subprocess.SubprocessError`, `check=False`, `timeout=5`). One harmless redundancy: `record_baselines` passes `mode="live"` which equals the model default — left for explicitness.

**2. Are the claims verifiable?** Yes — exact commands and exit codes:
- Full CI gate on the final diff: `uv run ruff check domain_scout/` (clean), `uv run ruff format --check domain_scout/` (clean), `uv run mypy domain_scout/` (Success, 51 files), `uv run pytest domain_scout/tests -m "not integration" -q` → **792 passed, 4 deselected, coverage 94.39%** (gate 92%).
- Generator + eval **end-to-end on a live-generated substrate**: `python -m domain_scout.eval --mode record --label domo-auto-20260224` recorded 2 domains and wrote a manifest (exit 0); `make eval` then scored it (both scorer legs, precision/recall 1.000), **exit 0**.
- Loud-failure exit codes, all **exit 1** with branded messages: manifest→absent file; manifest→corrupt (sha mismatch); files present but **no manifest** (the interrupted-record case); empty dir. `git check-ignore baselines/manifest.json` confirms the substrate stays untracked.

**3. Matches existing patterns?** Atomic `.tmp` + rename mirrors the repo's certstream/parquet atomic-write pattern (referenced in CLAUDE.md). Pydantic `BaseModel` manifest models match the existing `EvalReport`/`GroundTruthEntry` style. `EntityInput(company_name=…, seed_domain=list)` mirrors the pre-existing `evaluate_live` construction. Fail-loud with a typed error + friendly CLI message follows `CTOrgSearchUnavailableError` (#163). `eval.py` is a standalone CLI — not imported by `api.py`/`cli.py` and not in the public `__init__` exports, so no public API break for the SHA-pinned `domain-scout-api` / path-dep `insurance-market-db`.

**(d) Design Gates** — this touches **gate 3** (string/snapshot coupling to a drifting external universe with no drift detection). The fix ships drift **detection** in the same PR: a missing/corrupt substrate is now a hard error, and provenance stamps (`generated_at`, `scorer`) plus a scorer-drift warning make decay detectable rather than silent. **Not fully addressed (disclosed, not symptom-patched silently):**
- The learned leg still re-scores post-pipeline state (**#187**) — an existing approximation, orthogonal to substrate freshness, untouched here.
- Decay is *detectable* (timestamp + scorer-drift warning) but not *auto-alerted* on a months-old `generated_at`. Charter of #188 is absent files; a periodic auto-staleness gate is a reasonable follow-up (noted, not built) — the PR claims only "detectable," which is accurate.

## Adversarial review

Two synchronous general-purpose adversarial passes on the final diff. The first flagged an interrupted-`record` partial-substrate hole (the exact gate-3 class); it was fixed at root by making the manifest mandatory + atomic. The re-review of the final diff returned **SHIP, no BLOCKER / no SHOULD-FIX**, confirming the hole is closed on all traced branches.

## Deploy notes

`baselines/` is git-ignored (substrate is not committed). On the production box, run `make eval-baselines` once to generate the full substrate before relying on `make eval` — full sweep is 399 entities × one serialized live discovery each (bounded by `total_timeout=90s` + crt.sh rate limits/breaker); use `make eval-baselines LIMIT=N` for quick refreshes.