### PR TITLE
Add renovate.json to enable the fleet Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>minghsuy/dgx-infra"]
+}


### PR DESCRIPTION
## What

Adds `renovate.json` extending the shared fleet preset:

```json
{ "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>minghsuy/dgx-infra"] }
```

## Why

`renovate-global.json` lists this repo in `repositories`, but with
`requireConfig: "required"` and `onboarding: false`, a repo without a
local config is skipped silently — no PR, no error, nothing in the run log
(minghsuy/dgx-infra#154). This repo has never had a config file, so
Renovate has been doing nothing here despite being listed. This PR adds
exactly the file #144 added to dgx-infra for the same reason, and matches
the pattern already live in `insurance-market-db`, `bike-ride-analyzer`,
and `sc-real-estate-diligence`.

## Expect noise — but not immediately

The fleet preset (`dgx-infra/default.json`) sets
`schedule: ["before 9am on monday"]` and `minimumReleaseAge: "7 days"`,
so merging does not open an immediate burst — the first scheduled run is
the next Monday before 9am PT, capped at `prConcurrentLimit: 10` /
`prHourlyLimit: 4`. The only thing that can open immediately is a
`vulnerabilityAlerts` PR (`schedule: ["at any time"]`). This repo has
never been scanned, so expect that first Monday run to catch up on
everything that's drifted.

No existing Dependabot config in this repo (checked
`.github/dependabot.yml`, 404), so there is no automerge-overlap risk of
the kind found on pressure-companion (dgx-infra PR review on #276).

## CI status

Default branch (`main`) CI is green (`gh run list --repo minghsuy/domain-scout --branch main --limit 5` — most recent runs `success`). This repo is public; confirmed none of its workflows use `self-hosted` runners, so no fork-PR RCE exposure applies here or to this change. Gated by the repo's own CI like any other PR.

## Answers to the pre-PR checklist

**(a) Leftovers from drafting?** No — single new file, diff is exactly the
4-line config.

**(b) Is every claim something I ran, with command and exit code?**
- Confirmed no existing config at any accepted path (`renovate.json`,
  `renovate.json5`, `.renovaterc`, `.renovaterc.json`,
  `.github/renovate.json`, `.github/renovate.json5`,
  `.renovaterc.json5`, and a `renovate` key in `package.json`) via the
  GitHub Contents API (`gh api repos/minghsuy/domain-scout/contents/<path>`,
  all 404).
- Confirmed no `.github/dependabot.yml` (404) — no automerge overlap.
- Confirmed `default.json` exists on dgx-infra's default branch so the
  `extends` target resolves.
- Confirmed the branch/commit landed: `gh api
  repos/minghsuy/domain-scout/contents/renovate.json?ref=add-renovate-config` returns the
  file with the expected content.

**(c) Does it match the file's existing patterns?** Yes — same
`extends: ["github>minghsuy/dgx-infra"]` shape as
`insurance-market-db/renovate.json` and `bike-ride-analyzer/renovate.json`;
no repo-specific `packageRules` added since this repo has no known
dependency or CI-file carve-out need.

**(d) Data-System Design Gates?** None apply. This is a 3-line Renovate
config file — it doesn't classify, match, score, link, or aggregate data.

Related: minghsuy/dgx-infra#154
