### PR TITLE
Add durable repository guidance for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@
 
 Before starting any task:
 
-1. Run `gh pr list --repo minghsuy/domain-scout --state open`. For each
-   potentially overlapping PR, inspect its changed paths with
-   `gh pr view <number> --repo minghsuy/domain-scout --json files`; stop if it
-   already touches the target files.
+1. Run `gh pr list --repo minghsuy/domain-scout --state open`. For
+   implementation work, inspect each potentially overlapping PR with
+   `gh pr view <number> --repo minghsuy/domain-scout --json files`; stop if a
+   different PR already touches the target files. When reviewing or addressing
+   the current PR, do not treat that PR itself as a collision.
 2. Read `CLAUDE.md` for the current architecture and evaluation constraints.
 3. Run `git status --short --branch`. If the tree is dirty, do not stash,
    clean, reset, or overwrite local/generated data; work from an isolated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# domain-scout — Agent Guidelines
+
+## Pre-Session Checklist
+
+Before starting any task:
+
+1. Run `gh pr list --repo minghsuy/domain-scout --state open` and stop if an
+   open PR already touches the target files.
+2. Read `CLAUDE.md` for the current architecture and evaluation constraints.
+3. Run `git status --short --branch`; preserve all local and generated data.
+
+## Verification
+
+On a fresh checkout or worktree, run `make install` first so the API, cache,
+metrics, and evaluation extras are present. Run `make check` before pushing; it
+covers formatting, Ruff, strict mypy, and the mocked unit suite.
+
+- Do not run `make test-integration` without explicit permission; it calls live
+  crt.sh, RDAP, and DNS services.
+- Do not run `make eval-baselines` without explicit permission; it performs a
+  long live-data recording pass and replaces the local evaluation manifest.
+
+## Repository Boundaries
+
+- This is the public MIT engine. Keep billing, API-key tiers, customer usage,
+  and other commercial-service behavior in `domain-scout-api`.
+- Keep public-facing files free of domain-specific customer/use-case language.
+- Never commit `SPEC.md`, security reports, secrets, caches, or the git-ignored
+  `baselines/` evaluation substrate.
+- Use `uv`, not `pip`, for dependency management.
+
+## Code Review Rules
+
+### Public evidence contracts
+
+- Treat CLI/API fields, `EvidenceRecord`, `RunMetadata`, scoring inputs, and
+  profile semantics as public contracts. Prefer additive compatibility, retain
+  provenance, and require focused tests plus changelog documentation for
+  externally observable changes.
+
+### Async and network safety
+
+- Flag blocking network or database calls on the event loop, unbounded fan-out,
+  and missing timeouts or circuit-breaker behavior. Keep synchronous crt.sh
+  Postgres work in an executor, preserve bounded concurrency, and never use the
+  JSON fallback for organization-verified searches because it lacks subject
+  organization data.
+
+### Evaluation integrity
+
+- The baseline manifest is the source of truth: missing, partial, stale-schema,
+  absent-file, or hash-mismatched substrates must fail loudly. Recording must
+  write snapshots first and publish the manifest atomically last; never turn a
+  missing substrate into a passing or neutral evaluation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,14 @@
 
 Before starting any task:
 
-1. Run `gh pr list --repo minghsuy/domain-scout --state open` and stop if an
-   open PR already touches the target files.
+1. Run `gh pr list --repo minghsuy/domain-scout --state open`. For each
+   potentially overlapping PR, inspect its changed paths with
+   `gh pr view <number> --repo minghsuy/domain-scout --json files`; stop if it
+   already touches the target files.
 2. Read `CLAUDE.md` for the current architecture and evaluation constraints.
-3. Run `git status --short --branch`; preserve all local and generated data.
+3. Run `git status --short --branch`. If the tree is dirty, do not stash,
+   clean, reset, or overwrite local/generated data; work from an isolated
+   worktree based on the current upstream branch.
 
 ## Verification
 
@@ -28,6 +32,9 @@ covers formatting, Ruff, strict mypy, and the mocked unit suite.
 - Never commit `SPEC.md`, security reports, secrets, caches, or the git-ignored
   `baselines/` evaluation substrate.
 - Use `uv`, not `pip`, for dependency management.
+- Overlap with `CLAUDE.md` is intentional so non-Claude agents receive the
+  same safety rules. Keep duplicated constraints aligned when either file
+  changes.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,18 @@
 
 Before starting any task:
 
-1. Run `gh pr list --repo minghsuy/domain-scout --state open`. For
-   implementation work, inspect each potentially overlapping PR with
-   `gh pr view <number> --repo minghsuy/domain-scout --json files`; stop if a
-   different PR already touches the target files. When reviewing or addressing
-   the current PR, do not treat that PR itself as a collision.
+1. List open PRs with `gh` when available; otherwise use the connected GitHub
+   tool/API. For implementation work, inspect each potentially overlapping
+   PR's changed files and stop if a different PR already touches the target
+   files. When reviewing or addressing the current PR, do not treat that PR
+   itself as a collision. If neither GitHub path is available, stop before
+   writing target files and report that collision checking is unavailable.
 2. Read `CLAUDE.md` for the current architecture and evaluation constraints.
 3. Run `git status --short --branch`. If the tree is dirty, do not stash,
    clean, reset, or overwrite local/generated data; work from an isolated
-   worktree based on the current upstream branch.
+   worktree based on the configured upstream branch. If there is no upstream
+   or remote, use the current `HEAD` or a known local base branch and note that
+   choice.
 
 ## Verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,12 @@ domain-scout — Discover internet domains associated with a business entity via
 ```bash
 make install       # uv sync --all-groups --all-extras
 make test          # unit tests only (excludes integration)
-make test-integration  # hits real external services (crt.sh, RDAP, DNS)
+make test-integration  # live crt.sh/RDAP/DNS; requires explicit permission
 make lint          # ruff check + mypy --strict
 make format        # ruff fix + ruff format
 make check         # format + lint + test
 make eval          # run evaluation harness against the baseline substrate
-make eval-baselines  # (re)generate the git-ignored baseline substrate + manifest
+make eval-baselines  # live, long, replaces local manifest; explicit permission required
 ```
 
 ## Tech Stack
@@ -106,6 +106,8 @@ domain_scout/
 - **The manifest is mandatory.** `make eval` fails loudly (`EvalSubstrateError`, non-zero exit) when there is no manifest, when the manifest is unparseable, or when it references an absent or sha-mismatched file. Loose `{label_id}.json` files without a manifest are **not** trusted (an interrupted `record` run can leave a partial set) — the manifest is proof of a completed run, so `record` writes it atomically and last. So `make eval` requires a prior `make eval-baselines`; a missing/partial substrate must never read as a passing/neutral eval. It also warns (stderr) when the substrate's recorded scorer differs from the current one.
 - **Substrate schema is versioned** (`manifest.substrate_schema`, currently 2). Since #187, `record` captures each domain's score-time inputs (pre-`_infra_boost` sources, pre-dedup evidence aggregates, boost outcome) so the eval's learned leg replays production scoring exactly instead of approximating it from post-pipeline state. A substrate recorded under an older schema is refused loudly with a re-record message — never silently scored the approximated way.
 - Full-sweep cost: 399 ground-truth entities × one live discovery each, serialized, bounded by `total_timeout=90s` and the crt.sh rate limits/circuit breaker. Budget a long single-threaded run; use `LIMIT` for quick refreshes.
+- Do not run `make eval-baselines` without explicit permission: it makes live
+  external calls and replaces the local git-ignored baseline manifest.
 
 ## Conventions
 
@@ -118,5 +120,6 @@ domain_scout/
 ## Testing
 
 - **565 unit tests** + 4 integration tests (deselected by default)
-- Integration tests hit real crt.sh, RDAP, and DNS — use `make test-integration`
+- Integration tests hit real crt.sh, RDAP, and DNS. Do not run
+  `make test-integration` without explicit permission.
 - Seed domain choice significantly affects live results — different seeds find different SANs


### PR DESCRIPTION
Closes #200.

## What changed

- Adds a pre-session checklist for PR collision checks and dirty-worktree preservation.
- Records the fresh-worktree bootstrap and complete local verification gate.
- Documents the public/commercial repository boundary and protected evaluation assets.
- Adds review rules for public evidence contracts, async/network safety, and evaluation integrity.

## Validation

- `make install`
- `make check`: Ruff, formatting, strict mypy across 51 source files, and 797 tests passed (4 deselected); total coverage 94.56%.