### PR TITLE
Fix un-awaited AsyncMock warnings in subsidiary tests

### DIFF
--- a/domain_scout/tests/test_subsidiary.py
+++ b/domain_scout/tests/test_subsidiary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -262,11 +262,12 @@ class TestSubsidiaryExpansion:
         from domain_scout.models import EntityInput
 
         ct_mock = AsyncMock(search_by_org=AsyncMock(return_value=[]))
+        dns_mock = MagicMock(bulk_resolve=AsyncMock(return_value={}))
         s = self._make_scout(
             _subsidiaries={"walmart": ["Jet.com Inc.", "Bonobos Inc."]},
             _ct=ct_mock,
             _rdap=AsyncMock(),
-            _dns=AsyncMock(bulk_resolve=AsyncMock(return_value={})),
+            _dns=dns_mock,
         )
 
         entity = EntityInput(company_name="Walmart Inc.", seed_domain=[])
@@ -277,6 +278,7 @@ class TestSubsidiaryExpansion:
         assert "Walmart Inc." in org_calls
         assert "Jet.com Inc." in org_calls
         assert "Bonobos Inc." in org_calls
+        dns_mock.reset.assert_called_once_with()
 
     def test_max_queries_cap(self) -> None:
         """subsidiary_max_queries caps the number of subsidiary searches."""
@@ -292,13 +294,14 @@ class TestSubsidiaryExpansion:
 
         subs = [f"Brand{i} Inc." for i in range(20)]
         ct_mock = AsyncMock(search_by_org=AsyncMock(return_value=[]))
+        dns_mock = MagicMock(bulk_resolve=AsyncMock(return_value={}))
         config = ScoutConfig(subsidiary_max_queries=3)
         s = self._make_scout(
             config=config,
             _subsidiaries={"test": subs},
             _ct=ct_mock,
             _rdap=AsyncMock(),
-            _dns=AsyncMock(bulk_resolve=AsyncMock(return_value={})),
+            _dns=dns_mock,
         )
 
         entity = EntityInput(company_name="Test Corp", seed_domain=[])
@@ -308,3 +311,4 @@ class TestSubsidiaryExpansion:
         org_calls = [call.args[0] for call in ct_mock.search_by_org.call_args_list]
         sub_calls = [c for c in org_calls if c.startswith("Brand")]
         assert len(sub_calls) == 3
+        dns_mock.reset.assert_called_once_with()


### PR DESCRIPTION
Closes #202.

## What changed

- Uses a synchronous `MagicMock` for the injected `DNSChecker` while keeping `bulk_resolve` asynchronous.
- Asserts the synchronous `reset()` contract in both affected subsidiary expansion tests.

## Why

The production `DNSChecker.reset()` method is synchronous. Injecting an `AsyncMock` for the entire object made the correct synchronous call create an un-awaited coroutine and emitted two RuntimeWarnings on every full test run.

## Validation

- Focused tests with `-W error::RuntimeWarning --no-cov`: 2 passed.
- `make check`: Ruff, formatting, strict mypy, and 797 tests passed (4 deselected), 94.56% coverage, with no warning summary.