### PR TITLE
fix: preserve CTScout attribution safety signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CTScout remote evidence now preserves the Worker contract version, match
   strategy, certificate counts, and all four attribution-safety annotations
   (`is_top_org_for_apex`, `apex_contested`, `apex_bulk_infra`, and
-  `dns_verified`) in typed `EvidenceRecord.ctscout_attribution` provenance
+  `dns_verified`) plus the source org/apex row identity in typed
+  `EvidenceRecord.ctscout_attribution` provenance
   (result schema 1.2). The derived `cert_volume_attribution_safe` flag is false
   for non-dominant, contested, bulk-infrastructure, or DNS-unverified rows, so
   raw issuance volume cannot silently masquerade as ownership evidence. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CTScout remote evidence now preserves the Worker contract version, match
+  strategy, certificate counts, and all four attribution-safety annotations
+  (`is_top_org_for_apex`, `apex_contested`, `apex_bulk_infra`, and
+  `dns_verified`) in typed `EvidenceRecord.ctscout_attribution` provenance
+  (result schema 1.2). The derived `cert_volume_attribution_safe` flag is false
+  for non-dominant, contested, bulk-infrastructure, or DNS-unverified rows, so
+  raw issuance volume cannot silently masquerade as ownership evidence. The
+  adapter now fails closed on missing/incompatible `X-API-Version`, unreviewed
+  response fields, and semantic-only fallback suggestions instead of
+  collapsing them into an unexplained empty result. (#204)
 - The learned-scorer artifact's own persisted metrics are now consumed at load
   time (#183). An acceptance gate skips the isotonic calibration layer when the
   artifact reports `lr_calibrated_ece > lr_ece` — true for the shipped v1

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,22 @@ class DiscoveredDomain(BaseModel):
 ### EvidenceRecord
 
 ```python
+class CTScoutAttributionProvenance(BaseModel):
+    api_version: str                     # reviewed CTScout X-API-Version
+    org: str                             # legal organization on the warehouse row
+    apex_domain: str                     # apex attributed by that row
+    match_type: Literal["exact", "semantic", "none"]
+    org_match_strategy: Literal[
+        "substring", "word", "normalized", "semantic", "none", "not_applicable"
+    ]
+    cert_count: int                      # issuance volume; not ownership proof
+    subdomain_count: int
+    is_top_org_for_apex: bool
+    apex_contested: bool
+    apex_bulk_infra: bool
+    dns_verified: bool
+    cert_volume_attribution_safe: bool   # false if any volume-safety guard fails
+
 class EvidenceRecord(BaseModel):
     source_type: str                     # e.g. "ct_org_match", "ct_san_expansion", "dns_guess"
     description: str                     # human-readable explanation
@@ -113,13 +129,17 @@ class EvidenceRecord(BaseModel):
     cert_id: int | None = None           # crt.sh certificate ID (links to https://crt.sh/?id=N)
     cert_org: str | None = None          # O= field from the certificate
     similarity_score: float | None = None  # org-name similarity 0.0-1.0
+    rdap_org: str | None = None
+    signal_type: str | None = None
+    signal_weight: float | None = None
+    ctscout_attribution: CTScoutAttributionProvenance | None = None
 ```
 
 ### RunMetadata
 
 ```python
 class RunMetadata(BaseModel):
-    schema_version: str = "1.1"          # output schema version (1.1: scorer_id/scorer_version)
+    schema_version: str = "1.2"          # 1.2: typed CTScout attribution provenance
     tool_version: str                    # domain-scout package version
     timestamp: datetime                  # UTC timestamp of the run
     elapsed_seconds: float               # wall-clock duration

--- a/domain_scout/__init__.py
+++ b/domain_scout/__init__.py
@@ -8,6 +8,7 @@ from domain_scout._logging import configure_logging
 from domain_scout.delta import compute_delta
 from domain_scout.models import (
     ChangedDomain,
+    CTScoutAttributionProvenance,
     DeltaReport,
     DeltaSummary,
     DeltaWarning,
@@ -29,6 +30,7 @@ __all__ = [
     "EntityInput",
     "DiscoveredDomain",
     "EvidenceRecord",
+    "CTScoutAttributionProvenance",
     "RunMetadata",
     "ScoutResult",
     "DomainChange",

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -33,6 +33,8 @@ class CTScoutAttributionProvenance(BaseModel):
     """
 
     api_version: str
+    org: str
+    apex_domain: str
     match_type: Literal["exact", "semantic", "none"]
     org_match_strategy: Literal[
         "substring", "word", "normalized", "semantic", "none", "not_applicable"

--- a/domain_scout/models.py
+++ b/domain_scout/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 — Pydantic needs runtime import
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -24,6 +24,28 @@ class EntityInput(BaseModel):
         return self
 
 
+class CTScoutAttributionProvenance(BaseModel):
+    """Trust metadata carried by one CTScout warehouse row.
+
+    CTScout's certificate counts are discovery signals, not ownership facts.
+    ``cert_volume_attribution_safe`` is therefore false whenever the row is
+    non-dominant, contested, bulk infrastructure, or DNS-unverified.
+    """
+
+    api_version: str
+    match_type: Literal["exact", "semantic", "none"]
+    org_match_strategy: Literal[
+        "substring", "word", "normalized", "semantic", "none", "not_applicable"
+    ]
+    cert_count: int = Field(ge=0)
+    subdomain_count: int = Field(ge=0)
+    is_top_org_for_apex: bool
+    apex_contested: bool
+    apex_bulk_infra: bool
+    dns_verified: bool
+    cert_volume_attribution_safe: bool
+
+
 class EvidenceRecord(BaseModel):
     """A single piece of attribution evidence for a discovered domain."""
 
@@ -36,6 +58,7 @@ class EvidenceRecord(BaseModel):
     rdap_org: str | None = None
     signal_type: str | None = None
     signal_weight: float | None = None
+    ctscout_attribution: CTScoutAttributionProvenance | None = None
 
 
 class ScoringInputs(BaseModel):
@@ -90,8 +113,8 @@ class DiscoveredDomain(BaseModel):
 class RunMetadata(BaseModel):
     """Metadata about a domain-scout run for audit and reproducibility."""
 
-    # 1.1: added DiscoveredDomain.scorer_id / scorer_version (additive, issue #184)
-    schema_version: str = "1.1"
+    # 1.2: added EvidenceRecord.ctscout_attribution (additive, issue #204)
+    schema_version: str = "1.2"
     tool_version: str
     timestamp: datetime
     elapsed_seconds: float

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -145,7 +145,7 @@ def _dedup_evidence(evidence: list[EvidenceRecord]) -> list[EvidenceRecord]:
     Returns stable sorted output for deterministic serialization."""
     deduped: list[EvidenceRecord] = []
     seen_org: dict[tuple[str, str | None], EvidenceRecord] = {}
-    seen_other: set[tuple[str, str | None]] = set()
+    seen_other: set[tuple[str, str | None, str | None, str | None]] = set()
     for ev in evidence:
         if ev.cert_org is not None:
             key = (ev.source_type, ev.cert_org)
@@ -156,12 +156,26 @@ def _dedup_evidence(evidence: list[EvidenceRecord]) -> list[EvidenceRecord]:
             ):
                 seen_org[key] = ev
         else:
-            key_other = (ev.source_type, ev.seed_domain)
+            provenance = ev.ctscout_attribution
+            key_other = (
+                ev.source_type,
+                ev.seed_domain,
+                provenance.org if provenance is not None else None,
+                provenance.apex_domain if provenance is not None else None,
+            )
             if key_other not in seen_other:
                 seen_other.add(key_other)
                 deduped.append(ev)
     deduped.extend(seen_org.values())
-    deduped.sort(key=lambda e: (e.source_type, e.cert_org or ""))
+    deduped.sort(
+        key=lambda e: (
+            e.source_type,
+            e.cert_org or "",
+            e.seed_domain or "",
+            e.ctscout_attribution.org if e.ctscout_attribution is not None else "",
+            e.ctscout_attribution.apex_domain if e.ctscout_attribution is not None else "",
+        )
+    )
     return deduped
 
 

--- a/domain_scout/scout.py
+++ b/domain_scout/scout.py
@@ -37,6 +37,7 @@ from domain_scout.matching.entity_match import (
     strict_org_name_match,
 )
 from domain_scout.models import (
+    CTScoutAttributionProvenance,
     DiscoveredDomain,
     EntityInput,
     EvidenceRecord,
@@ -126,6 +127,16 @@ def _signal_fields(source_tag: str) -> dict[str, Any]:
     if sig is None:
         return {}
     return {"signal_type": sig[0], "signal_weight": sig[1]}
+
+
+def _ctscout_attribution(
+    rec: dict[str, Any],
+) -> CTScoutAttributionProvenance | None:
+    """Validate optional remote CTScout trust metadata before publishing it."""
+    raw = rec.get("ctscout_attribution")
+    if raw is None:
+        return None
+    return CTScoutAttributionProvenance.model_validate(raw)
 
 
 def _dedup_evidence(evidence: list[EvidenceRecord]) -> list[EvidenceRecord]:
@@ -996,6 +1007,7 @@ class Scout:
         # word-bounded name match too. Subsidiary tags keep their looser intent.
         if source_tag == "ct_org_match" and not strict_org_name_match(org_name, cert_org):
             return results
+        ctscout_attribution = _ctscout_attribution(rec)
 
         sans = _extract_sans(rec)
         cn = rec.get("common_name", "")
@@ -1023,6 +1035,7 @@ class Scout:
                     cert_id=_int_or_none(rec.get("cert_id")),
                     cert_org=cert_org,
                     similarity_score=round(similarity, 4),
+                    ctscout_attribution=ctscout_attribution,
                     **_signal_fields(source_tag),
                 )
             )
@@ -1084,6 +1097,7 @@ class Scout:
         seed_base = extract_base_domain(seed_domain)
 
         for rec in records:
+            ctscout_attribution = _ctscout_attribution(rec)
             sans = _extract_sans(rec)
             cn = rec.get("common_name", "")
             cert_org = rec.get("org_name")
@@ -1117,6 +1131,7 @@ class Scout:
                             source_type="ct_seed_subdomain",
                             description=f"Subdomain of seed domain {seed_domain}",
                             seed_domain=seed_domain,
+                            ctscout_attribution=ctscout_attribution,
                             **_signal_fields("ct_seed_subdomain"),
                         )
                     )
@@ -1130,6 +1145,7 @@ class Scout:
                             source_type="ct_san_expansion",
                             description=f"Found on same cert as seed domain {seed_domain}",
                             seed_domain=seed_domain,
+                            ctscout_attribution=ctscout_attribution,
                             **_signal_fields("ct_san_expansion"),
                         )
                     )
@@ -1140,6 +1156,7 @@ class Scout:
                             source_type="ct_seed_related",
                             description=f"Found in CT search for {seed_domain}",
                             seed_domain=seed_domain,
+                            ctscout_attribution=ctscout_attribution,
                             **_signal_fields("ct_seed_related"),
                         )
                     )
@@ -1161,6 +1178,7 @@ class Scout:
                                 cert_id=_int_or_none(rec.get("cert_id")),
                                 cert_org=cert_org,
                                 similarity_score=round(sim, 4),
+                                ctscout_attribution=ctscout_attribution,
                                 **_signal_fields("ct_org_match"),
                             )
                         )

--- a/domain_scout/sources/ctscout_remote.py
+++ b/domain_scout/sources/ctscout_remote.py
@@ -105,6 +105,10 @@ def _validate_response(
             "CTScout returned semantic candidates, but the Domain Scout CT source only "
             "accepts authoritative warehouse rows; corroborate the candidates separately"
         )
+    if domains and (match_type != "exact" or org_match_strategy == "semantic"):
+        raise CTScoutSchemaError(
+            "CTScout returned domains outside the authoritative exact-match path"
+        )
 
     validated_domains: list[Mapping[str, object]] = []
     for index, row in enumerate(domains):

--- a/domain_scout/sources/ctscout_remote.py
+++ b/domain_scout/sources/ctscout_remote.py
@@ -73,6 +73,8 @@ def _require_count(row: Mapping[str, object], field: str) -> int:
 def _validate_response(
     api_version: str | None,
     data: Any,
+    *,
+    organization_query: bool,
 ) -> tuple[list[Mapping[str, object]], str, str]:
     if api_version != CTSCOUT_API_VERSION:
         shown = api_version if api_version is not None else "missing"
@@ -105,10 +107,19 @@ def _validate_response(
             "CTScout returned semantic candidates, but the Domain Scout CT source only "
             "accepts authoritative warehouse rows; corroborate the candidates separately"
         )
-    if domains and (match_type != "exact" or org_match_strategy == "semantic"):
-        raise CTScoutSchemaError(
-            "CTScout returned domains outside the authoritative exact-match path"
+    if domains:
+        if match_type != "exact":
+            raise CTScoutSchemaError(
+                "CTScout returned domains outside the authoritative exact-match path"
+            )
+        authoritative_strategies = (
+            {"substring", "word", "normalized"} if organization_query else {"not_applicable"}
         )
+        if org_match_strategy not in authoritative_strategies:
+            query_kind = "organization" if organization_query else "seed-domain"
+            raise CTScoutSchemaError(
+                f"CTScout returned a nonmatching strategy for a {query_kind} query"
+            )
 
     validated_domains: list[Mapping[str, object]] = []
     for index, row in enumerate(domains):
@@ -193,7 +204,11 @@ class CTScoutRemoteSource:
             log.warning("ctscout_remote.query_failed", error=str(exc))
             raise
 
-        rows, match_type, org_match_strategy = _validate_response(api_version, data)
+        rows, match_type, org_match_strategy = _validate_response(
+            api_version,
+            data,
+            organization_query=company_name is not None,
+        )
 
         # Convert warehouse rows to CT-compatible records
         records: list[dict[str, object]] = []

--- a/domain_scout/sources/ctscout_remote.py
+++ b/domain_scout/sources/ctscout_remote.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
@@ -11,6 +12,113 @@ if TYPE_CHECKING:
     from domain_scout.config import ScoutConfig
 
 log = structlog.get_logger()
+
+CTSCOUT_API_VERSION = "2026-07-11"
+
+_RESPONSE_FIELDS = frozenset(
+    {
+        "domains",
+        "total",
+        "truncated",
+        "upgrade_hint",
+        "source",
+        "candidates",
+        "match_type",
+        "org_match_strategy",
+        "empty_reason",
+    }
+)
+_DOMAIN_FIELDS = frozenset(
+    {
+        "org",
+        "apex_domain",
+        "cert_count",
+        "subdomain_count",
+        "first_seen",
+        "last_seen",
+        "is_top_org_for_apex",
+        "apex_contested",
+        "apex_bulk_infra",
+        "dns_verified",
+    }
+)
+_MATCH_TYPES = frozenset({"exact", "semantic", "none"})
+_ORG_MATCH_STRATEGIES = frozenset(
+    {"substring", "word", "normalized", "semantic", "none", "not_applicable"}
+)
+
+
+class CTScoutSchemaError(RuntimeError):
+    """The remote response does not match the adapter's reviewed contract."""
+
+
+class CTScoutSemanticFallbackUnsupportedError(RuntimeError):
+    """The remote returned weak semantic suggestions that this source cannot promote."""
+
+
+def _require_bool(row: Mapping[str, object], field: str) -> bool:
+    value = row.get(field)
+    if not isinstance(value, bool):
+        raise CTScoutSchemaError(f"CTScout domain field {field!r} must be a boolean")
+    return value
+
+
+def _require_count(row: Mapping[str, object], field: str) -> int:
+    value = row.get(field)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise CTScoutSchemaError(f"CTScout domain field {field!r} must be a non-negative integer")
+    return value
+
+
+def _validate_response(
+    api_version: str | None,
+    data: Any,
+) -> tuple[list[Mapping[str, object]], str, str]:
+    if api_version != CTSCOUT_API_VERSION:
+        shown = api_version if api_version is not None else "missing"
+        raise CTScoutSchemaError(
+            "Unsupported CTScout X-API-Version "
+            f"{shown!r}; this adapter requires {CTSCOUT_API_VERSION!r}"
+        )
+    if not isinstance(data, Mapping):
+        raise CTScoutSchemaError("CTScout response body must be a JSON object")
+
+    unknown_response_fields = set(data) - _RESPONSE_FIELDS
+    if unknown_response_fields:
+        raise CTScoutSchemaError(
+            "CTScout response contains unreviewed fields: "
+            + ", ".join(sorted(str(field) for field in unknown_response_fields))
+        )
+
+    match_type = data.get("match_type")
+    if not isinstance(match_type, str) or match_type not in _MATCH_TYPES:
+        raise CTScoutSchemaError("CTScout response has an invalid or missing match_type")
+    org_match_strategy = data.get("org_match_strategy")
+    if not isinstance(org_match_strategy, str) or org_match_strategy not in _ORG_MATCH_STRATEGIES:
+        raise CTScoutSchemaError("CTScout response has an invalid or missing org_match_strategy")
+
+    domains = data.get("domains")
+    if not isinstance(domains, list):
+        raise CTScoutSchemaError("CTScout response field 'domains' must be a list")
+    if match_type == "semantic" or (not domains and data.get("candidates")):
+        raise CTScoutSemanticFallbackUnsupportedError(
+            "CTScout returned semantic candidates, but the Domain Scout CT source only "
+            "accepts authoritative warehouse rows; corroborate the candidates separately"
+        )
+
+    validated_domains: list[Mapping[str, object]] = []
+    for index, row in enumerate(domains):
+        if not isinstance(row, Mapping):
+            raise CTScoutSchemaError(f"CTScout domains[{index}] must be a JSON object")
+        unknown_domain_fields = set(row) - _DOMAIN_FIELDS
+        if unknown_domain_fields:
+            raise CTScoutSchemaError(
+                f"CTScout domains[{index}] contains unreviewed fields: "
+                + ", ".join(sorted(str(field) for field in unknown_domain_fields))
+            )
+        validated_domains.append(row)
+
+    return validated_domains, match_type, org_match_strategy
 
 
 class CTScoutRemoteSource:
@@ -76,16 +184,25 @@ class CTScoutRemoteSource:
                 )
                 resp.raise_for_status()
                 data = resp.json()
+                api_version = resp.headers.get("X-API-Version")
         except Exception as exc:
             log.warning("ctscout_remote.query_failed", error=str(exc))
             raise
 
+        rows, match_type, org_match_strategy = _validate_response(api_version, data)
+
         # Convert warehouse rows to CT-compatible records
         records: list[dict[str, object]] = []
-        for row in data.get("domains", []):
+        for row in rows:
             apex = row.get("apex_domain")
-            if not apex:
+            if not isinstance(apex, str) or not apex:
                 continue
+            cert_count = _require_count(row, "cert_count")
+            subdomain_count = _require_count(row, "subdomain_count")
+            is_top_org_for_apex = _require_bool(row, "is_top_org_for_apex")
+            apex_contested = _require_bool(row, "apex_contested")
+            apex_bulk_infra = _require_bool(row, "apex_bulk_infra")
+            dns_verified = _require_bool(row, "dns_verified")
             records.append(
                 {
                     "cert_id": None,
@@ -95,8 +212,25 @@ class CTScoutRemoteSource:
                     "not_before": row.get("first_seen"),
                     "not_after": row.get("last_seen"),
                     "source_type": "ctscout_warehouse",
-                    "cert_count": row.get("cert_count", 0),
-                    "subdomain_count": row.get("subdomain_count", 0),
+                    "cert_count": cert_count,
+                    "subdomain_count": subdomain_count,
+                    "ctscout_attribution": {
+                        "api_version": api_version,
+                        "match_type": match_type,
+                        "org_match_strategy": org_match_strategy,
+                        "cert_count": cert_count,
+                        "subdomain_count": subdomain_count,
+                        "is_top_org_for_apex": is_top_org_for_apex,
+                        "apex_contested": apex_contested,
+                        "apex_bulk_infra": apex_bulk_infra,
+                        "dns_verified": dns_verified,
+                        "cert_volume_attribution_safe": (
+                            is_top_org_for_apex
+                            and not apex_contested
+                            and not apex_bulk_infra
+                            and dns_verified
+                        ),
+                    },
                 }
             )
 

--- a/domain_scout/sources/ctscout_remote.py
+++ b/domain_scout/sources/ctscout_remote.py
@@ -197,6 +197,9 @@ class CTScoutRemoteSource:
             apex = row.get("apex_domain")
             if not isinstance(apex, str) or not apex:
                 continue
+            org = row.get("org")
+            if not isinstance(org, str) or not org:
+                raise CTScoutSchemaError("CTScout domain field 'org' must be a non-empty string")
             cert_count = _require_count(row, "cert_count")
             subdomain_count = _require_count(row, "subdomain_count")
             is_top_org_for_apex = _require_bool(row, "is_top_org_for_apex")
@@ -206,7 +209,7 @@ class CTScoutRemoteSource:
             records.append(
                 {
                     "cert_id": None,
-                    "org_name": row.get("org"),
+                    "org_name": org,
                     "common_name": apex,
                     "san_dns_names": [apex],
                     "not_before": row.get("first_seen"),
@@ -216,6 +219,8 @@ class CTScoutRemoteSource:
                     "subdomain_count": subdomain_count,
                     "ctscout_attribution": {
                         "api_version": api_version,
+                        "org": org,
+                        "apex_domain": apex,
                         "match_type": match_type,
                         "org_match_strategy": org_match_strategy,
                         "cert_count": cert_count,

--- a/domain_scout/tests/fixtures/ctscout_scan_2026-07-11.json
+++ b/domain_scout/tests/fixtures/ctscout_scan_2026-07-11.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "X-API-Version": "2026-07-11",
+    "X-Tier": "pro"
+  },
+  "body": {
+    "domains": [
+      {
+        "org": "Dominator Inc",
+        "apex_domain": "pollution.example",
+        "cert_count": 50000,
+        "subdomain_count": 12,
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-07-10",
+        "is_top_org_for_apex": true,
+        "apex_contested": true,
+        "apex_bulk_infra": false,
+        "dns_verified": true
+      }
+    ],
+    "total": 1,
+    "truncated": false,
+    "source": "warehouse",
+    "match_type": "exact",
+    "org_match_strategy": "substring"
+  }
+}

--- a/domain_scout/tests/test_ctscout_remote.py
+++ b/domain_scout/tests/test_ctscout_remote.py
@@ -296,3 +296,21 @@ class TestCTScoutRemoteSource:
             ),
         ):
             await source.search_by_org("Goldman")
+
+    @pytest.mark.asyncio
+    async def test_nonempty_none_match_fails_closed(self) -> None:
+        """Contradictory no-match rows must never become attribution evidence."""
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        payload = _body([_domain()])
+        payload["match_type"] = "none"
+        payload["org_match_strategy"] = "none"
+        mock_client = _make_httpx_mock(payload)
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="authoritative exact-match"),
+        ):
+            await source.search_by_org("Goldman")

--- a/domain_scout/tests/test_ctscout_remote.py
+++ b/domain_scout/tests/test_ctscout_remote.py
@@ -95,6 +95,8 @@ class TestCTScoutRemoteSource:
         assert records[0]["cert_count"] == 200
         assert records[0]["ctscout_attribution"] == {
             "api_version": CTSCOUT_API_VERSION,
+            "org": "Goldman Sachs & Co. LLC",
+            "apex_domain": "gs.com",
             "match_type": "exact",
             "org_match_strategy": "substring",
             "cert_count": 200,

--- a/domain_scout/tests/test_ctscout_remote.py
+++ b/domain_scout/tests/test_ctscout_remote.py
@@ -2,16 +2,55 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from domain_scout.config import ScoutConfig
-from domain_scout.sources.ctscout_remote import CTScoutRemoteSource
+from domain_scout.scout import Scout
+from domain_scout.sources.ctscout_remote import (
+    CTSCOUT_API_VERSION,
+    CTScoutRemoteSource,
+    CTScoutSchemaError,
+    CTScoutSemanticFallbackUnsupportedError,
+)
 
 
-def _make_httpx_mock(json_payload: object = None, status_code: int = 200) -> AsyncMock:
+def _domain(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "org": "Goldman Sachs & Co. LLC",
+        "apex_domain": "gs.com",
+        "cert_count": 200,
+        "subdomain_count": 114,
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-03-14",
+        "is_top_org_for_apex": True,
+        "apex_contested": False,
+        "apex_bulk_infra": False,
+        "dns_verified": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def _body(domains: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "domains": domains,
+        "total": len(domains),
+        "source": "warehouse",
+        "match_type": "exact",
+        "org_match_strategy": "substring",
+    }
+
+
+def _make_httpx_mock(
+    json_payload: object = None,
+    status_code: int = 200,
+    api_version: str | None = CTSCOUT_API_VERSION,
+) -> AsyncMock:
     """Build a mock httpx.AsyncClient returning the given JSON response."""
     mock_response = MagicMock()
     mock_response.status_code = status_code
@@ -23,6 +62,7 @@ def _make_httpx_mock(json_payload: object = None, status_code: int = 200) -> Asy
             response=mock_response,
         )
     mock_response.json.return_value = json_payload or {}
+    mock_response.headers = {"X-API-Version": api_version} if api_version is not None else {}
 
     mock_client = AsyncMock()
     mock_client.post.return_value = mock_response
@@ -39,19 +79,7 @@ class TestCTScoutRemoteSource:
         config = ScoutConfig(ctscout_api_key="ds_free_test")
         source = CTScoutRemoteSource(config)
 
-        mock_data = {
-            "domains": [
-                {
-                    "org": "Goldman Sachs & Co. LLC",
-                    "apex_domain": "gs.com",
-                    "cert_count": 200,
-                    "subdomain_count": 114,
-                    "first_seen": "2026-01-01",
-                    "last_seen": "2026-03-14",
-                },
-            ],
-            "total": 1,
-        }
+        mock_data = _body([_domain()])
         mock_client = _make_httpx_mock(mock_data)
 
         with patch(
@@ -65,24 +93,37 @@ class TestCTScoutRemoteSource:
         assert records[0]["san_dns_names"] == ["gs.com"]
         assert records[0]["source_type"] == "ctscout_warehouse"
         assert records[0]["cert_count"] == 200
+        assert records[0]["ctscout_attribution"] == {
+            "api_version": CTSCOUT_API_VERSION,
+            "match_type": "exact",
+            "org_match_strategy": "substring",
+            "cert_count": 200,
+            "subdomain_count": 114,
+            "is_top_org_for_apex": True,
+            "apex_contested": False,
+            "apex_bulk_infra": False,
+            "dns_verified": True,
+            "cert_volume_attribution_safe": True,
+        }
+
+        # The adapter metadata must survive the synthetic CT record boundary
+        # and reach the public EvidenceRecord model.
+        processed = Scout(config)._process_org_record(
+            records[0],
+            "Goldman Sachs",
+            "ct_org_match",
+        )
+        evidence = processed[0][1].evidence[0]
+        assert evidence.ctscout_attribution is not None
+        assert evidence.ctscout_attribution.api_version == CTSCOUT_API_VERSION
+        assert evidence.ctscout_attribution.cert_volume_attribution_safe is True
 
     @pytest.mark.asyncio
     async def test_search_by_domain_returns_records(self) -> None:
         config = ScoutConfig(ctscout_api_key="ds_free_test")
         source = CTScoutRemoteSource(config)
 
-        mock_data = {
-            "domains": [
-                {
-                    "org": "Goldman Sachs & Co. LLC",
-                    "apex_domain": "gs.com",
-                    "cert_count": 200,
-                    "subdomain_count": 114,
-                    "first_seen": "2026-01-01",
-                    "last_seen": "2026-03-14",
-                },
-            ],
-        }
+        mock_data = _body([_domain()])
         mock_client = _make_httpx_mock(mock_data)
 
         with patch(
@@ -101,12 +142,12 @@ class TestCTScoutRemoteSource:
         config = ScoutConfig(ctscout_api_key="ds_free_test")
         source = CTScoutRemoteSource(config)
 
-        mock_data = {
-            "domains": [
-                {"org": "Test", "apex_domain": None, "cert_count": 1},
-                {"org": "Test", "apex_domain": "test.com", "cert_count": 2},
-            ],
-        }
+        mock_data = _body(
+            [
+                _domain(org="Test", apex_domain=None, cert_count=1),
+                _domain(org="Test", apex_domain="test.com", cert_count=2),
+            ]
+        )
         mock_client = _make_httpx_mock(mock_data)
 
         with patch(
@@ -147,3 +188,109 @@ class TestCTScoutRemoteSource:
         config = ScoutConfig(ctscout_api_key="ds_free_test")
         source = CTScoutRemoteSource(config)
         assert await source.get_cert_org(12345) is None
+
+    @pytest.mark.asyncio
+    async def test_golden_worker_contract_fixture(self) -> None:
+        """The reviewed Worker response remains fully consumed by this adapter."""
+        fixture_path = Path(__file__).with_name("fixtures") / "ctscout_scan_2026-07-11.json"
+        fixture = json.loads(fixture_path.read_text())
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        mock_client = _make_httpx_mock(
+            fixture["body"],
+            api_version=fixture["headers"]["X-API-Version"],
+        )
+
+        with patch(
+            "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            records = await source.search_by_org("Dominator")
+
+        provenance = records[0]["ctscout_attribution"]
+        assert isinstance(provenance, dict)
+        assert provenance["is_top_org_for_apex"] is True
+        assert provenance["apex_contested"] is True
+        assert provenance["apex_bulk_infra"] is False
+        assert provenance["dns_verified"] is True
+        # A contested argmax is still a volume guess, even with 50,000 certs.
+        assert provenance["cert_volume_attribution_safe"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version", [None, "2026-07-12"])
+    async def test_missing_or_unreviewed_api_version_fails_closed(
+        self, api_version: str | None
+    ) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        mock_client = _make_httpx_mock(_body([_domain()]), api_version=api_version)
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="X-API-Version"),
+        ):
+            await source.search_by_org("Goldman Sachs")
+
+    @pytest.mark.asyncio
+    async def test_unreviewed_domain_field_fails_closed(self) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        mock_client = _make_httpx_mock(_body([_domain(future_attribution_signal="review me")]))
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="future_attribution_signal"),
+        ):
+            await source.search_by_org("Goldman Sachs")
+
+    @pytest.mark.asyncio
+    async def test_missing_safety_annotation_fails_closed(self) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        row = _domain()
+        del row["dns_verified"]
+        mock_client = _make_httpx_mock(_body([row]))
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="dns_verified"),
+        ):
+            await source.search_by_org("Goldman Sachs")
+
+    @pytest.mark.asyncio
+    async def test_semantic_fallback_is_explicitly_unsupported(self) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        mock_client = _make_httpx_mock(
+            {
+                "domains": [],
+                "total": 0,
+                "source": "warehouse",
+                "match_type": "semantic",
+                "org_match_strategy": "semantic",
+                "empty_reason": "semantic_offered",
+                "candidates": [
+                    {
+                        "org": "Goldman Sachs Group, Inc.",
+                        "similarity": 0.91,
+                        "top_apex_domain": "goldmansachs.com",
+                    }
+                ],
+            }
+        )
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(
+                CTScoutSemanticFallbackUnsupportedError,
+                match="corroborate",
+            ),
+        ):
+            await source.search_by_org("Goldman")

--- a/domain_scout/tests/test_ctscout_remote.py
+++ b/domain_scout/tests/test_ctscout_remote.py
@@ -126,6 +126,7 @@ class TestCTScoutRemoteSource:
         source = CTScoutRemoteSource(config)
 
         mock_data = _body([_domain()])
+        mock_data["org_match_strategy"] = "not_applicable"
         mock_client = _make_httpx_mock(mock_data)
 
         with patch(
@@ -314,3 +315,34 @@ class TestCTScoutRemoteSource:
             pytest.raises(CTScoutSchemaError, match="authoritative exact-match"),
         ):
             await source.search_by_org("Goldman")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("strategy", ["none", "not_applicable"])
+    async def test_org_query_rejects_nonmatching_strategy(self, strategy: str) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        payload = _body([_domain()])
+        payload["org_match_strategy"] = strategy
+        mock_client = _make_httpx_mock(payload)
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="organization query"),
+        ):
+            await source.search_by_org("Goldman")
+
+    @pytest.mark.asyncio
+    async def test_seed_query_rejects_org_match_strategy(self) -> None:
+        source = CTScoutRemoteSource(ScoutConfig(ctscout_api_key="ds_free_test"))
+        mock_client = _make_httpx_mock(_body([_domain()]))
+
+        with (
+            patch(
+                "domain_scout.sources.ctscout_remote.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(CTScoutSchemaError, match="seed-domain query"),
+        ):
+            await source.search_by_domain("gs.com")

--- a/domain_scout/tests/test_evidence.py
+++ b/domain_scout/tests/test_evidence.py
@@ -63,8 +63,8 @@ class TestRunMetadata:
             elapsed_seconds=1.0,
             domains_found=5,
         )
-        # 1.1: DiscoveredDomain gained scorer_id/scorer_version (#184)
-        assert meta.schema_version == "1.1"
+        # 1.2: EvidenceRecord gained CTScout attribution provenance (#204)
+        assert meta.schema_version == "1.2"
 
     def test_config_snapshot(self) -> None:
         cfg = ScoutConfig(total_timeout=120)

--- a/domain_scout/tests/test_evidence.py
+++ b/domain_scout/tests/test_evidence.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from domain_scout.config import ScoutConfig
-from domain_scout.models import EvidenceRecord, RunMetadata
+from domain_scout.models import CTScoutAttributionProvenance, EvidenceRecord, RunMetadata
 
 # --- Discovery Profiles ---
 
@@ -215,6 +215,42 @@ class TestEvidenceDedup:
         # 1 rdap record → 1
         deduped = _dedup_evidence(evidence)
         assert len(deduped) == 2
+
+    def test_distinct_ctscout_rows_survive_seed_evidence_dedup(self) -> None:
+        """A contested apex keeps provenance for every warehouse organization."""
+        from domain_scout.scout import _dedup_evidence
+
+        def provenance(org: str, cert_count: int) -> CTScoutAttributionProvenance:
+            return CTScoutAttributionProvenance(
+                api_version="2026-07-11",
+                org=org,
+                apex_domain="shared.example",
+                match_type="exact",
+                org_match_strategy="not_applicable",
+                cert_count=cert_count,
+                subdomain_count=1,
+                is_top_org_for_apex=cert_count == 20,
+                apex_contested=True,
+                apex_bulk_infra=False,
+                dns_verified=True,
+                cert_volume_attribution_safe=False,
+            )
+
+        evidence = [
+            EvidenceRecord(
+                source_type="ct_seed_subdomain",
+                description=f"Warehouse row for {org}",
+                seed_domain="shared.example",
+                ctscout_attribution=provenance(org, cert_count),
+            )
+            for org, cert_count in (("Alpha Inc", 20), ("Beta LLC", 3))
+        ]
+
+        deduped = _dedup_evidence(evidence)
+        assert len(deduped) == 2
+        assert {
+            item.ctscout_attribution.org for item in deduped if item.ctscout_attribution is not None
+        } == {"Alpha Inc", "Beta LLC"}
 
 
 class TestConfigToDict:


### PR DESCRIPTION
Fixes #204.

Preserves the CTScout Worker trust boundary in Domain Scout:
- publishes all four attribution-safety annotations plus counts, match strategy, Worker API version, and source org/apex row identity in typed EvidenceRecord provenance
- derives cert_volume_attribution_safe only for dominant, uncontested, non-bulk, DNS-verified rows; certificate volume itself remains outside scoring
- preserves every distinct organization on contested seed/apex lookups through row-aware evidence deduplication
- fails closed on missing/incompatible X-API-Version, unreviewed fields, contradictory match states, and query-mode-incompatible strategies
- reports semantic-only fallback as explicitly unsupported instead of an unexplained empty result
- bumps and documents the additive public result schema to 1.2
- adds a sanitized golden fixture for Worker API version 2026-07-11 and propagation/compatibility/dedup/state-invariant regressions

Validation at 5e9acfa98198decd6cc0538e44a2a65d5f4e29ba:
- make install
- make check: 808 passed, 4 integration tests deselected, 94.61% coverage
- Ruff, formatting, and strict mypy green

Per repository policy, no live integration or eval-baselines command was run.