### PR TITLE
Release domain-scout 0.12.0

### DIFF
--- a/.github/release_preflight.py
+++ b/.github/release_preflight.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for tag-triggered releases."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import NoReturn
+
+PROJECT_NAME = "domain-scout-ct"
+
+
+def _fail(message: str) -> NoReturn:
+    raise ValueError(message)
+
+
+def _project_version(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle).get("project", {})
+    version = project.get("version")
+    if not isinstance(version, str) or not version:
+        _fail("pyproject.toml has no non-empty project.version")
+    return version
+
+
+def _locked_project_version(root: Path) -> str:
+    with (root / "uv.lock").open("rb") as handle:
+        packages = tomllib.load(handle).get("package", [])
+    matches = [
+        package
+        for package in packages
+        if package.get("name") == PROJECT_NAME and package.get("source", {}).get("editable") == "."
+    ]
+    if len(matches) != 1:
+        _fail(f"uv.lock must contain exactly one editable {PROJECT_NAME!r} package")
+    version = matches[0].get("version")
+    if not isinstance(version, str) or not version:
+        _fail(f"uv.lock has no version for editable {PROJECT_NAME!r}")
+    return version
+
+
+def _validate_changelog(root: Path, version: str) -> None:
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    heading = re.compile(
+        rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\s*$",
+        re.MULTILINE,
+    )
+    match = heading.search(changelog)
+    if match is None:
+        _fail(f"CHANGELOG.md has no dated [{version}] release section")
+    next_heading = re.search(r"^## \[", changelog[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(changelog)
+    release_notes = changelog[match.end() : end]
+    if re.search(r"^- ", release_notes, re.MULTILINE) is None:
+        _fail(f"CHANGELOG.md [{version}] release section has no entries")
+
+
+def _validate_main_ancestry(root: Path, main_ref: str) -> None:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", "HEAD", main_ref],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode == 1:
+        _fail(f"release commit is not contained in {main_ref}")
+    detail = result.stderr.strip() or "git merge-base failed"
+    _fail(f"could not verify release ancestry against {main_ref}: {detail}")
+
+
+def validate_release(root: Path, tag: str, main_ref: str) -> str:
+    version = _project_version(root)
+    expected_tag = f"v{version}"
+    if tag != expected_tag:
+        _fail(f"release tag {tag!r} does not match project version {expected_tag!r}")
+
+    locked_version = _locked_project_version(root)
+    if locked_version != version:
+        _fail(
+            f"uv.lock project version {locked_version!r} does not match pyproject.toml {version!r}"
+        )
+
+    _validate_changelog(root, version)
+    _validate_main_ancestry(root, main_ref)
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--main-ref", default="origin/main")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    try:
+        version = validate_release(args.root.resolve(), args.tag, args.main_ref)
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+        print(f"release preflight failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"release preflight passed for {PROJECT_NAME} {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/release_preflight.py
+++ b/.github/release_preflight.py
@@ -11,35 +11,40 @@ import tomllib
 from pathlib import Path
 from typing import NoReturn
 
-PROJECT_NAME = "domain-scout-ct"
+
+class ReleasePreflightError(ValueError):
+    """Release metadata or ancestry is inconsistent."""
 
 
 def _fail(message: str) -> NoReturn:
-    raise ValueError(message)
+    raise ReleasePreflightError(message)
 
 
-def _project_version(root: Path) -> str:
+def _project_metadata(root: Path) -> tuple[str, str]:
     with (root / "pyproject.toml").open("rb") as handle:
         project = tomllib.load(handle).get("project", {})
+    name = project.get("name")
+    if not isinstance(name, str) or not name:
+        _fail("pyproject.toml has no non-empty project.name")
     version = project.get("version")
     if not isinstance(version, str) or not version:
         _fail("pyproject.toml has no non-empty project.version")
-    return version
+    return name, version
 
 
-def _locked_project_version(root: Path) -> str:
+def _locked_project_version(root: Path, project_name: str) -> str:
     with (root / "uv.lock").open("rb") as handle:
         packages = tomllib.load(handle).get("package", [])
     matches = [
         package
         for package in packages
-        if package.get("name") == PROJECT_NAME and package.get("source", {}).get("editable") == "."
+        if package.get("name") == project_name and package.get("source", {}).get("editable") == "."
     ]
     if len(matches) != 1:
-        _fail(f"uv.lock must contain exactly one editable {PROJECT_NAME!r} package")
+        _fail(f"uv.lock must contain exactly one editable {project_name!r} package")
     version = matches[0].get("version")
     if not isinstance(version, str) or not version:
-        _fail(f"uv.lock has no version for editable {PROJECT_NAME!r}")
+        _fail(f"uv.lock has no version for editable {project_name!r}")
     return version
 
 
@@ -75,13 +80,13 @@ def _validate_main_ancestry(root: Path, main_ref: str) -> None:
     _fail(f"could not verify release ancestry against {main_ref}: {detail}")
 
 
-def validate_release(root: Path, tag: str, main_ref: str) -> str:
-    version = _project_version(root)
+def validate_release(root: Path, tag: str, main_ref: str) -> tuple[str, str]:
+    project_name, version = _project_metadata(root)
     expected_tag = f"v{version}"
     if tag != expected_tag:
         _fail(f"release tag {tag!r} does not match project version {expected_tag!r}")
 
-    locked_version = _locked_project_version(root)
+    locked_version = _locked_project_version(root, project_name)
     if locked_version != version:
         _fail(
             f"uv.lock project version {locked_version!r} does not match pyproject.toml {version!r}"
@@ -89,7 +94,7 @@ def validate_release(root: Path, tag: str, main_ref: str) -> str:
 
     _validate_changelog(root, version)
     _validate_main_ancestry(root, main_ref)
-    return version
+    return project_name, version
 
 
 def main() -> int:
@@ -100,12 +105,12 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        version = validate_release(args.root.resolve(), args.tag, args.main_ref)
-    except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+        project_name, version = validate_release(args.root.resolve(), args.tag, args.main_ref)
+    except (OSError, tomllib.TOMLDecodeError, ReleasePreflightError) as error:
         print(f"release preflight failed: {error}", file=sys.stderr)
         return 1
 
-    print(f"release preflight passed for {PROJECT_NAME} {version}")
+    print(f"release preflight passed for {project_name} {version}")
     return 0
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run ruff check domain_scout/
-      - run: uv run ruff format --check domain_scout/
+      - run: uv run ruff check domain_scout/ .github/release_preflight.py
+      - run: uv run ruff format --check domain_scout/ .github/release_preflight.py
 
   typecheck:
     needs: changes
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run mypy domain_scout/
+      - run: uv run mypy domain_scout/ .github/release_preflight.py
 
   test:
     needs: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,31 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  preflight:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch main branch
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+      - name: Validate release metadata and ancestry
+        run: >-
+          python3 .github/release_preflight.py
+          --tag "$GITHUB_REF_NAME"
+          --main-ref origin/main
+
   lint:
+    needs: preflight
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -16,10 +39,11 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run ruff check domain_scout/
-      - run: uv run ruff format --check domain_scout/
+      - run: uv run ruff check domain_scout/ .github/release_preflight.py
+      - run: uv run ruff format --check domain_scout/ .github/release_preflight.py
 
   typecheck:
+    needs: preflight
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -29,9 +53,10 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-groups --all-extras
-      - run: uv run mypy domain_scout/ --ignore-missing-imports
+      - run: uv run mypy domain_scout/ .github/release_preflight.py
 
   test:
+    needs: preflight
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +79,15 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv build
+      - run: uvx twine check dist/*
+      - name: Smoke-test built wheel
+        run: |
+          uv venv /tmp/domain-scout-release-smoke
+          uv pip install --python /tmp/domain-scout-release-smoke/bin/python dist/*.whl
+          EXPECTED_VERSION="${GITHUB_REF_NAME#v}"
+          /tmp/domain-scout-release-smoke/bin/python -c \
+            "from importlib.metadata import version; assert version('domain-scout-ct') == '$EXPECTED_VERSION'"
+          /tmp/domain-scout-release-smoke/bin/domain-scout --help
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -77,8 +111,19 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
           awk "/^## \[${VERSION//./\\.}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md > /tmp/release-notes.md
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" dist/* --title "$GITHUB_REF_NAME" --notes-file /tmp/release-notes.md
+      - name: Create or repair GitHub Release
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file /tmp/release-notes.md
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file /tmp/release-notes.md
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-30
+
 ### Added
+- Protected API endpoints now accept `Authorization: Bearer` as a fallback to
+  `X-API-Key`, with the existing header retaining precedence when both are
+  present. (#129)
+- `EntityInput` now supports seed-domain-only discovery without a company-name
+  hint. Organization, GLEIF, and subsidiary-name searches are skipped when the
+  name is absent, while domain-side evidence remains available. (#130)
 - CTScout remote evidence now preserves the Worker contract version, match
   strategy, certificate counts, and all four attribution-safety annotations
   (`is_top_org_for_apex`, `apex_contested`, `apex_bulk_infra`, and
@@ -55,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference only the current run's outputs.
 
 ### Changed
+- One `httpx.AsyncClient` is now shared for the duration of each scan across
+  CT JSON, RDAP, and GeoDNS calls. Corroboration failures and phase timeouts are
+  surfaced in `RunMetadata.errors` and metrics instead of being silently
+  discarded. (#166, #167, #189)
+- API scans now close local warehouse and GLEIF connections reliably and keep
+  synchronous construction work off the event loop. Cache initialization
+  degrades safely when the optional dependency is absent or a DuckDB writer
+  lock is held, and invalid concurrency environment values fall back to the
+  documented default. (#164, #169, #193)
 - The eval's learned leg now replays production scoring **exactly** instead of
   approximating it (#187, substrate schema 2). `--mode record` captures each
   candidate domain's score-time inputs (`ScoringInputs`: pre-`_infra_boost`
@@ -126,6 +143,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Local source query hardening** — reject absolute-path traversal and validate
+  dynamic DuckDB identifiers before query construction. (#150, #153)
+- **crt.sh availability** — add a bounded Postgres connection timeout and
+  expose organization-search unavailability rather than silently returning an
+  empty result when the JSON API cannot provide certificate subject
+  organizations. (#163, #165)
+- **CLI documentation** — all command examples now include the required
+  `scout` subcommand. (#162)
 - **First-instance-wins breakers** — CT/RDAP circuit breakers moved to
   class-level registries keyed by `(failure_threshold, recovery_timeout)`, so
   effective thresholds no longer depend on instance construction order; an

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ test-integration:
 	uv run pytest domain_scout/tests -m integration -v --timeout=120 --no-cov
 
 lint:
-	uv run ruff check domain_scout/
-	uv run mypy domain_scout/
+	uv run ruff check domain_scout/ .github/release_preflight.py
+	uv run mypy domain_scout/ .github/release_preflight.py
 
 format:
-	uv run ruff check --fix domain_scout/
-	uv run ruff format domain_scout/
+	uv run ruff check --fix domain_scout/ .github/release_preflight.py
+	uv run ruff format domain_scout/ .github/release_preflight.py
 
 eval:
 	uv run python -m domain_scout.eval --mode baseline

--- a/domain_scout/tests/test_release_preflight.py
+++ b/domain_scout/tests/test_release_preflight.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[2] / ".github" / "release_preflight.py"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def release_tree(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "domain-scout-ct"\nversion = "0.12.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "domain-scout-ct"\n'
+        'version = "0.12.0"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n"
+        "## [0.12.0] - 2026-07-30\n\n### Added\n\n- A release.\n\n"
+        "## [0.11.0] - 2026-04-01\n\n- Earlier.\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "release")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return tmp_path
+
+
+def _run(root: Path, tag: str = "v0.12.0") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "--tag",
+            tag,
+            "--main-ref",
+            "origin/main",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_release_preflight_accepts_consistent_main_release(release_tree: Path) -> None:
+    result = _run(release_tree)
+    assert result.returncode == 0
+    assert "release preflight passed for domain-scout-ct 0.12.0" in result.stdout
+
+
+def test_release_preflight_rejects_tag_version_mismatch(release_tree: Path) -> None:
+    result = _run(release_tree, tag="v0.11.0")
+    assert result.returncode == 1
+    assert "does not match project version" in result.stderr
+
+
+def test_release_preflight_rejects_lock_version_mismatch(release_tree: Path) -> None:
+    (release_tree / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "domain-scout-ct"\n'
+        'version = "0.11.0"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    result = _run(release_tree)
+    assert result.returncode == 1
+    assert "uv.lock project version" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "release_section",
+    [
+        "",
+        "## [0.12.0] - 2026-07-30\n\n### Added\n\n",
+        "## [0.12.0]\n\n- Missing date.\n",
+    ],
+)
+def test_release_preflight_rejects_missing_or_empty_notes(
+    release_tree: Path, release_section: str
+) -> None:
+    (release_tree / "CHANGELOG.md").write_text(
+        f"# Changelog\n\n## [Unreleased]\n\n{release_section}"
+        "## [0.11.0] - 2026-04-01\n\n- Earlier.\n",
+        encoding="utf-8",
+    )
+    result = _run(release_tree)
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stderr
+
+
+def test_release_preflight_rejects_commit_outside_main(release_tree: Path) -> None:
+    (release_tree / "branch-only.txt").write_text("not on main\n", encoding="utf-8")
+    _git(release_tree, "add", "branch-only.txt")
+    _git(release_tree, "commit", "-m", "branch only")
+
+    result = _run(release_tree)
+    assert result.returncode == 1
+    assert "not contained in origin/main" in result.stderr

--- a/domain_scout/tests/test_release_preflight.py
+++ b/domain_scout/tests/test_release_preflight.py
@@ -80,6 +80,21 @@ def test_release_preflight_rejects_lock_version_mismatch(release_tree: Path) -> 
     assert "uv.lock project version" in result.stderr
 
 
+def test_release_preflight_uses_project_name_from_manifest(release_tree: Path) -> None:
+    (release_tree / "pyproject.toml").write_text(
+        '[project]\nname = "renamed-package"\nversion = "0.12.0"\n',
+        encoding="utf-8",
+    )
+    (release_tree / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "renamed-package"\n'
+        'version = "0.12.0"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    result = _run(release_tree)
+    assert result.returncode == 0
+    assert "release preflight passed for renamed-package 0.12.0" in result.stdout
+
+
 @pytest.mark.parametrize(
     "release_section",
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "domain-scout-ct"
-version = "0.11.0"
+version = "0.12.0"
 description = "Discover internet domains associated with a business entity via CT logs, RDAP, and DNS"
 requires-python = ">=3.12"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "domain-scout-ct"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Prepares the reviewed `domain-scout` tree for a `0.12.0` release.

This PR will:

- bump the project and lockfile versions
- complete and rotate the changelog
- add fail-closed, tested release metadata and ancestry validation
- align tag-time validation with normal CI
- make same-tag GitHub release creation safe to rerun after a partial workflow
  failure
- build, metadata-check, and clean-install smoke-test the exact artifacts before
  publication

No tag, GitHub release, or PyPI publication will be created from this PR.

## Why

The repository is 51 commits ahead of `v0.11.0`, while the prior tree still
produced `0.11.0` artifacts. The tag workflow did not reject that mismatch and
could leave a partial GitHub release when PyPI subsequently rejected the
duplicate artifact version.

## Validation

- `uv lock --check`
- Ruff check and format check
- strict mypy over `domain_scout/` and the release preflight
- 816 non-integration tests passed; 4 live integration tests intentionally
  deselected; 94.64% coverage
- 8 focused release-preflight tests passed
- actionlint 1.7.7
- `uv build` and `twine check` for wheel and sdist
- clean-environment wheel install, `0.12.0` metadata/import assertion, and
  `domain-scout --help`

Release preflight was also exercised manually against matching and mismatched
tags. The release workflow itself is tag-only and is not invoked by this PR.

Fixes #206
