### PR TITLE
Bound review cost: no per-push reviews, pinned model (dgx-infra#188)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,10 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # No synchronize: reviews are once-per-lifecycle-transition (bounded cost,
+    # dgx-infra#188), not per-push. opened covers PRs created ready; drafts
+    # are skipped below and review on the draft->ready transition instead.
+    types: [opened, ready_for_review, reopened]
 
 # Cancel an older bridge run for this PR if a new push lands before it
 # finishes — prevents duplicate `@claude review` posts on rapid pushes.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,8 +30,8 @@ on:
     # are skipped below and review on the draft->ready transition instead.
     types: [opened, ready_for_review, reopened]
 
-# Cancel an older bridge run for this PR if a new push lands before it
-# finishes — prevents duplicate `@claude review` posts on rapid pushes.
+# Cancel an older bridge run for this PR if lifecycle events land in quick
+# succession — prevents duplicate `@claude review` posts.
 concurrency:
   group: claude-review-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   trigger-review:
     # Skip on drafts. Skip on bot-authored PRs (Dependabot, Renovate) — those
-    # don't need automated AI review and would burn PAT API calls per push.
+    # don't need automated AI review.
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     # Empty permissions block: gh pr comment uses BRIDGE_PAT (not GITHUB_TOKEN),

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Repository-owned bounded-cost pin (dgx-infra#188): the ambient CLI
+          # default can be quota-exhausted while sonnet remains available.
+          claude_args: --model sonnet
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/domain-scout
+++ b/domain-scout
@@ -1,1 +1,0 @@
-/home/miyang/domain-scout

--- a/domain-scout
+++ b/domain-scout
@@ -1,0 +1,1 @@
+/home/miyang/domain-scout


### PR DESCRIPTION
Rollout item 8 of dgx-infra#188 — the public repo, so the stateless private provider doesn't apply (hard rule: no self-hosted on public repos). The bounded-cost form here:

## What

- Bridge drops `synchronize`: reviews fire once per lifecycle transition (`opened` / `ready_for_review` / `reopened`; draft + bot guards unchanged) — never per push.
- Responder pins `claude_args: --model sonnet` (byte-identical to the fleet's model-pin test expectation) so review success never couples to the ambient CLI default's quota — the 2026-07-30 failure mode. The pin applies to interactive `@claude` too, which is the safe direction and unavoidable in the bridge architecture.

Reviewer-verified: fork-PR exposure unchanged (`pull_request` trigger, no secrets to forks, loud-fail guard pre-existing); branch protection requires only lint/typecheck/test — no review-status consumer; delete-and-repost + concurrency logic event-driven, unaffected. Ledger flips `ambient/push-churn` → `sonnet/ready-only` under the churn-is-synchronize semantics (dgx-infra#214).

(a) No leftovers (two stale per-push comments freshened per review). (b) Claims run as stated, audit fixture-classified `hosted/embedded/sonnet/ready-only/complete`, findings=0. (c) Fleet pin convention exact. (d) Review plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCDckF9qGf4q6aGrUUYEjj