### PR TITLE
add actionlint workflow gate

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,38 @@
+name: Workflow lint
+
+# A malformed GitHub Actions workflow can schedule zero jobs, leaving its
+# expected check absent instead of red. Validate every workflow on every PR so
+# schema errors fail visibly before merge (minghsuy/dgx-infra#141).
+#
+# No workflow-level paths filter: this is intended to be a required check, and
+# a filtered required workflow can remain "Expected" forever when it is skipped.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    # This repository is PUBLIC: PR jobs must stay on GitHub-hosted runners.
+    # Never route them to the fleet's self-hosted runner, where an untrusted
+    # fork could execute arbitrary code (dgx-infra STANDARDS.md non-negotiable).
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Lint workflow files
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --workdir /github/workspace \
+            -v "$PWD:/github/workspace:ro" \
+            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667  # v1.7.12


### PR DESCRIPTION
Adds `.github/workflows/actionlint.yml` — the fleet workflow-lint gate pinned to `rhysd/actionlint` by full image digest (v1.7.12) with a read-only workspace mount. **Public repo: the job runs on `ubuntu-latest`**, never the fleet's self-hosted runner (fork-PR RCE non-negotiable per dgx-infra STANDARDS.md). Existing workflows pre-checked with the pinned image: exit 0, so no prerequisite PR and no `.github/actionlint.yaml` (no custom runner labels in use).

Part of the strictly serial rollout minghsuy/dgx-infra#141 (previous: ct-entity-resolution#476).

Pre-PR verification (gate a–d; 38-line single-file diff, below the adversarial-review threshold — fleet template with only the runner + its comment changed for the public-repo case): (a) nothing novel beyond the documented hosted-runner swap; (b) verified as stated — pinned actionlint exits 0 over this worktree, `git diff --check` clean, ci-standards audit reports the worktree `[OK]` with no PUBLIC-SELFHOSTED finding; (c) matches the fleet gate convention; (d) no data-system surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML4BBpYXZKJWsCJywiR6tT